### PR TITLE
Deepreadonly should preserve optional keys

### DIFF
--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -167,5 +167,14 @@ describe('mapped types', () => {
     };
     type ReadonlyNestedArrayProps = DeepReadonly<NestedArrayProps>;
     a = {} as ReadonlyNestedArrayProps['first']['second'][number];
+
+    type NestedOptionalProps = {
+      first?: {
+        second: {};
+      };
+    };
+    type ReadonlyNestedOptionalProps = DeepReadonly<NestedOptionalProps>;
+    testType<ReadonlyNestedOptionalProps>({});
+    testType<ReadonlyNestedOptionalProps>({ first: { second: {} } });
   });
 });

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -31,17 +31,17 @@ export type SymmetricDifference<A, B> = SetDifference<A | B, A & B>;
  * FunctionKeys
  * @desc get union type of keys that are functions in object type `T`
  */
-export type FunctionKeys<T> = {
+export type FunctionKeys<T> = keyof {
   [K in keyof T]: T[K] extends Function ? K : never
-}[keyof T];
+};
 
 /**
  * NonFunctionKeys
  * @desc get union type of keys that are non-functions in object type `T`
  */
-export type NonFunctionKeys<T> = {
+export type NonFunctionKeys<T> = keyof {
   [K in keyof T]: T[K] extends Function ? never : K
-}[keyof T];
+};
 
 /**
  * Omit (complements Pick)


### PR DESCRIPTION
`DeepReadonly` as implemented right now has a side effect.  All optional keys are converted to required keys.  I think I found a small tweak to the implementation that allows us to preserve the optional key modifier!

I have added a couple test assertions that hopefully help clarify the issue I'm identifying.