### PR TITLE
Add DeepRequired

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This gives you the power to prioritize our work and support project contributors
 * [`SetComplement<A, A1>`](#setcomplementa-a1)
 * [`SymmetricDifference<A, B>`](#symmetricdifferencea-b)
 * [`NonNullable<A>`](#nonnullablea) (_\*standard-lib_)
+* [`NonUndefined<A>`](#nonundefineda)
 * [`Exclude<A, B>`](#excludea-b) (_\*standard-lib_)
 * [`Extract<A, B>`](#extracta-b) (_\*standard-lib_)
 
@@ -178,6 +179,12 @@ type ResultSet = SymmetricDifference<'1' | '2' | '3', '2' | '3' | '4'>;
 ### `NonNullable<A>`
 
 Exclude `null` and `undefined` from set `A`
+
+[⇧ back to top](#operations-on-sets)
+
+### `NonUndefined<A>`
+
+Exclude `undefined` from set `A`
 
 [⇧ back to top](#operations-on-sets)
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This gives you the power to prioritize our work and support project contributors
 * [`Unionize<T>`](#unionizet)
 * [`PromiseType<T>`](#promisetypet) (replaced deprecated `UnboxPromise<T>`)
 * [`DeepReadonly<T>`](#deepreadonlyt)
+* [`DeepRequired<T>`](#deeprequiredt)
 
 ## Flow's Utility Types
 
@@ -439,6 +440,36 @@ type ReadonlyNestedProps = DeepReadonly<NestedProps>;
 //   readonly first: {
 //     readonly second: {
 //       readonly name: string;
+//     };
+//   };
+// }
+```
+
+[⇧ back to top](#mapped-types)
+
+---
+
+### `DeepRequired<T>`
+
+Required that works for deeply nested structures
+
+**Usage:**
+
+```ts
+import { DeepRequired } from 'utility-types';
+
+type NestedProps = {
+  first?: {
+    second?: {
+      name?: string | null | undefined;
+    };
+  };
+};
+type RequiredNestedProps = DeepRequired<NestedProps>;
+// Expect: {
+//   first: {
+//     second: {
+//       name: string;
 //     };
 //   };
 // }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   FunctionKeys,
   Intersection,
   NonFunctionKeys,
+  NonUndefined,
   Omit,
   Overwrite,
   PromiseType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
 export {
   Assign,
   DeepReadonly,
+  DeepRequired,
   Diff,
   FunctionKeys,
   Intersection,

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -15,6 +15,7 @@ import {
   Unionize,
   PromiseType,
   DeepReadonly,
+  DeepRequired,
 } from './';
 
 /**
@@ -167,5 +168,27 @@ describe('mapped types', () => {
     };
     type ReadonlyNestedArrayProps = DeepReadonly<NestedArrayProps>;
     a = {} as ReadonlyNestedArrayProps['first']['second'][number];
+  });
+
+  it('DeepRequired', () => {
+    type NestedProps = {
+      first?: {
+        second?: {
+          name?: string | null | undefined;
+        };
+      };
+    };
+    let a: { name: string };
+
+    type RequiredNestedProps = DeepRequired<NestedProps>;
+    a = {} as RequiredNestedProps['first']['second'];
+
+    type NestedArrayProps = {
+      first?: {
+        second?: Array<{ name?: string | null | undefined } | null | undefined>;
+      };
+    };
+    type RequiredNestedArrayProps = DeepRequired<NestedArrayProps>;
+    a = {} as RequiredNestedArrayProps['first']['second'][number];
   });
 });

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -5,6 +5,7 @@ import {
   SetComplement,
   SymmetricDifference,
   FunctionKeys,
+  NonUndefined,
   NonFunctionKeys,
   Omit,
   Intersection,
@@ -69,6 +70,14 @@ describe('mapped types', () => {
     // Expect: "1" | "4"
     testType<ResultSet>('1');
     testType<ResultSet>('4');
+  });
+
+  it('NonUndefined', () => {
+    type ResultSet = NonUndefined<'1' | '2' | undefined>;
+    testType<ResultSet>('1');
+    testType<ResultSet>('2');
+    type ResultNever = NonUndefined<undefined>;
+    testType<ResultNever>({} as never);
   });
 
   it('FunctionKeys', () => {
@@ -174,7 +183,7 @@ describe('mapped types', () => {
     type NestedProps = {
       first?: {
         second?: {
-          name?: string | null | undefined;
+          name?: string;
         };
       };
     };
@@ -185,7 +194,7 @@ describe('mapped types', () => {
 
     type NestedArrayProps = {
       first?: {
-        second?: Array<{ name?: string | null | undefined } | null | undefined>;
+        second?: Array<{ name?: string } | undefined>;
       };
     };
     type RequiredNestedArrayProps = DeepRequired<NestedArrayProps>;

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -138,3 +138,29 @@ export interface _DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
 export type _DeepReadonlyObject<T> = {
   readonly [P in keyof T]: DeepReadonly<T[P]>
 };
+
+/**
+ * DeepRequired
+ * @desc Required that works for deeply nested structure
+ */
+export type DeepRequired<T> = T extends any[]
+  ? _DeepRequiredArray<T[number]>
+  : T extends object ? _DeepRequiredObject<T> : T;
+
+/**
+ * DeepRequiredArray
+ * @desc Nested array condition handler
+ * @private
+ */
+// tslint:disable-next-line:class-name
+export interface _DeepRequiredArray<T>
+  extends Array<DeepRequired<NonNullable<T>>> {}
+
+/**
+ * DeepRequiredObject
+ * @desc Nested object condition handler
+ * @private
+ */
+export type _DeepRequiredObject<T> = {
+  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
+};

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -28,6 +28,12 @@ export type SetComplement<A, A1 extends A> = SetDifference<A, A1>;
 export type SymmetricDifference<A, B> = SetDifference<A | B, A & B>;
 
 /**
+ * NonUndefined
+ * @desc Exclude undefined from set `A`
+ */
+export type NonUndefined<T> = T extends undefined ? never : T;
+
+/**
  * FunctionKeys
  * @desc get union type of keys that are functions in object type `T`
  */
@@ -154,7 +160,7 @@ export type DeepRequired<T> = T extends any[]
  */
 // tslint:disable-next-line:class-name
 export interface _DeepRequiredArray<T>
-  extends Array<DeepRequired<NonNullable<T>>> {}
+  extends Array<DeepRequired<NonUndefined<T>>> {}
 
 /**
  * DeepRequiredObject
@@ -162,5 +168,5 @@ export interface _DeepRequiredArray<T>
  * @private
  */
 export type _DeepRequiredObject<T> = {
-  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
+  [P in keyof T]-?: DeepRequired<NonUndefined<T[P]>>
 };


### PR DESCRIPTION
`DeepRequired` is to `Required` as `DeepReadonly` is to `Readonly`.

```ts
type NestedProps = {
  first?: {
    second?: {
      name?: string;
    };
  };
};
let a = {} as NestedProps;
const s1: string = a.first!.second!.name!;
let b = {} as DeepRequired<NestedProps>;
const s2: string = b.first.second.name;
```

<del>It is useful e.g. combining with `idx`:</del>

```ts
const s3: string | null | undefined = idx(b, _ => _.first.second.name); // idx will catch the error of reading from undefined or null
```