### PR TITLE
Add DeepNonNullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This gives you the power to prioritize our work and support project contributors
 * [`PromiseType<T>`](#promisetypet) (replaced deprecated `UnboxPromise<T>`)
 * [`DeepReadonly<T>`](#deepreadonlyt)
 * [`DeepRequired<T>`](#deeprequiredt)
+* [`DeepNonNullable<T>`](#deepnonnullablet)
 
 ## Flow's Utility Types
 
@@ -468,11 +469,41 @@ import { DeepRequired } from 'utility-types';
 type NestedProps = {
   first?: {
     second?: {
-      name?: string | null | undefined;
+      name?: string;
     };
   };
 };
 type RequiredNestedProps = DeepRequired<NestedProps>;
+// Expect: {
+//   first: {
+//     second: {
+//       name: string;
+//     };
+//   };
+// }
+```
+
+[⇧ back to top](#mapped-types)
+
+---
+
+### `DeepNonNullable<T>`
+
+NonNullable that works for deeply nested structure
+
+**Usage:**
+
+```ts
+import { DeepNonNullable } from 'utility-types';
+
+type NestedProps = {
+  first?: null | {
+    second?: null | {
+      name?: string | null | undefined;
+    };
+  };
+};
+type RequiredNestedProps = DeepNonNullable<NestedProps>;
 // Expect: {
 //   first: {
 //     second: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   Assign,
   DeepReadonly,
   DeepRequired,
+  DeepNonNullable,
   Diff,
   FunctionKeys,
   Intersection,

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -17,6 +17,7 @@ import {
   PromiseType,
   DeepReadonly,
   DeepRequired,
+  DeepNonNullable,
 } from './';
 
 /**
@@ -198,6 +199,28 @@ describe('mapped types', () => {
       };
     };
     type RequiredNestedArrayProps = DeepRequired<NestedArrayProps>;
+    a = {} as RequiredNestedArrayProps['first']['second'][number];
+  });
+
+  it('DeepNonNullable', () => {
+    type NestedProps = {
+      first?: null | {
+        second?: null | {
+          name?: null | string;
+        };
+      };
+    };
+    let a: { name: string };
+
+    type RequiredNestedProps = DeepNonNullable<NestedProps>;
+    a = {} as RequiredNestedProps['first']['second'];
+
+    type NestedArrayProps = {
+      first?: null | {
+        second?: Array<{ name?: string | null } | undefined | null>;
+      };
+    };
+    type RequiredNestedArrayProps = DeepNonNullable<NestedArrayProps>;
     a = {} as RequiredNestedArrayProps['first']['second'][number];
   });
 });

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -196,4 +196,3 @@ export interface _DeepNonNullableArray<T>
 export type _DeepNonNullableObject<T> = {
   [P in keyof T]-?: DeepNonNullable<NonNullable<T[P]>>
 };
-

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -170,3 +170,30 @@ export interface _DeepRequiredArray<T>
 export type _DeepRequiredObject<T> = {
   [P in keyof T]-?: DeepRequired<NonUndefined<T[P]>>
 };
+
+/**
+ * DeepNonNullable
+ * @desc NonNullable that works for deeply nested structure
+ */
+export type DeepNonNullable<T> = T extends any[]
+  ? _DeepNonNullableArray<T[number]>
+  : T extends object ? _DeepNonNullableObject<T> : T;
+
+/**
+ * DeepNonNullableArray
+ * @desc Nested array condition handler
+ * @private
+ */
+// tslint:disable-next-line:class-name
+export interface _DeepNonNullableArray<T>
+  extends Array<DeepNonNullable<NonNullable<T>>> {}
+
+/**
+ * DeepNonNullableObject
+ * @desc Nested object condition handler
+ * @private
+ */
+export type _DeepNonNullableObject<T> = {
+  [P in keyof T]-?: DeepNonNullable<NonNullable<T[P]>>
+};
+


### PR DESCRIPTION
As I mentioned in the PR https://github.com/piotrwitek/utility-types/pull/33 I have created a new type `DeepNonNullable`.

```ts
type NestedProps = {
  first?: null | {
    second?: null | {
      name?: null | string;
    };
  };
};
let a = {} as NestedProps;
const s1: string = a.first!.second!.name!;
let b = {} as DeepNonNullable<NestedProps>;
const s2: string = b.first.second.name;
```