### PR TITLE
Fix function handling for `Deep` types

### DIFF
--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -178,6 +178,16 @@ describe('mapped types', () => {
     };
     type ReadonlyNestedArrayProps = DeepReadonly<NestedArrayProps>;
     a = {} as ReadonlyNestedArrayProps['first']['second'][number];
+
+    type NestedFunctionProps = {
+      func: (value: string) => number;
+    };
+    type ReadonlyNestedFunctionProps = DeepReadonly<NestedFunctionProps>;
+    let b: {
+      readonly func: (value: string) => number;
+    };
+    b = { func: value => parseInt(value) } as ReadonlyNestedFunctionProps;
+    testType<Number>(b.func('1'));
   });
 
   it('DeepRequired', () => {
@@ -200,6 +210,16 @@ describe('mapped types', () => {
     };
     type RequiredNestedArrayProps = DeepRequired<NestedArrayProps>;
     a = {} as RequiredNestedArrayProps['first']['second'][number];
+
+    type NestedFunctionProps = {
+      func?: undefined | ((value: string) => number);
+    };
+    type RequiredNestedFunctionProps = DeepRequired<NestedFunctionProps>;
+    let b: {
+      func: (value: string) => number;
+    };
+    b = { func: value => parseInt(value) } as RequiredNestedFunctionProps;
+    testType<Number>(b.func('1'));
   });
 
   it('DeepNonNullable', () => {
@@ -223,4 +243,14 @@ describe('mapped types', () => {
     type RequiredNestedArrayProps = DeepNonNullable<NestedArrayProps>;
     a = {} as RequiredNestedArrayProps['first']['second'][number];
   });
+
+  type NestedFunctionProps = {
+    func?: null | undefined | ((value: string) => number);
+  };
+  type NonNullableNestedFunctionProps = DeepNonNullable<NestedFunctionProps>;
+  let b: {
+    func: (value: string) => number;
+  };
+  b = { func: value => parseInt(value) } as NonNullableNestedFunctionProps;
+  testType<Number>(b.func('1'));
 });

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -124,9 +124,11 @@ export type UnboxPromise<T> = PromiseType<T>;
  * DeepReadonly
  * @desc Readonly that works for deeply nested structure
  */
-export type DeepReadonly<T> = T extends any[]
-  ? _DeepReadonlyArray<T[number]>
-  : T extends object ? _DeepReadonlyObject<T> : T;
+export type DeepReadonly<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends any[]
+    ? _DeepReadonlyArray<T[number]>
+    : T extends object ? _DeepReadonlyObject<T> : T;
 
 /**
  * DeepReadonlyArray
@@ -149,9 +151,11 @@ export type _DeepReadonlyObject<T> = {
  * DeepRequired
  * @desc Required that works for deeply nested structure
  */
-export type DeepRequired<T> = T extends any[]
-  ? _DeepRequiredArray<T[number]>
-  : T extends object ? _DeepRequiredObject<T> : T;
+export type DeepRequired<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends any[]
+    ? _DeepRequiredArray<T[number]>
+    : T extends object ? _DeepRequiredObject<T> : T;
 
 /**
  * DeepRequiredArray
@@ -175,9 +179,11 @@ export type _DeepRequiredObject<T> = {
  * DeepNonNullable
  * @desc NonNullable that works for deeply nested structure
  */
-export type DeepNonNullable<T> = T extends any[]
-  ? _DeepNonNullableArray<T[number]>
-  : T extends object ? _DeepNonNullableObject<T> : T;
+export type DeepNonNullable<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends any[]
+    ? _DeepNonNullableArray<T[number]>
+    : T extends object ? _DeepNonNullableObject<T> : T;
 
 /**
  * DeepNonNullableArray


### PR DESCRIPTION
Fix function handling for `Deep` types:

![image](https://user-images.githubusercontent.com/1812118/48992358-47ebc680-f172-11e8-87c7-0e74aac56a08.png)

![image](https://user-images.githubusercontent.com/1812118/48992366-52a65b80-f172-11e8-9988-c7c6d39c914f.png)

This PR is inspired by https://github.com/facebookincubator/idx/pull/61 but I don't think `Deep` types should handling the return type of nested function.

E.g.

```ts
DeepRequired<{ func?: undefined | (() => number | undefined) }>
```

should become 

```ts
{ func: () => number | undefined }
```

instead of:

```ts
{ func: () => number }
```