### PR TITLE
Add $ObjMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This gives you the power to prioritize our work and support project contributors
 * [`$PropertyType<T, K>`](#propertytypet-k)
 * [`$ElementType<T, K>`](#elementtypet-k)
 * [`$Call<T>`](#callt)
+* [`$ObjMap<T, F>`](#objmapt-f)
 
 ## Deprecated API (use at own risk)
 * `getReturnOfExpression()` - from TS v2.0 it's better to use type-level `ReturnType` instead
@@ -669,6 +670,36 @@ type PropType = $Call<ExtractPropType<Obj>>; // number
 type ExtractReturnType<T extends () => any> = (arg: T) => ReturnType<T>;
 type Fn = () => number;
 type FnReturnType = $Call<ExtractReturnType<Fn>>; // number
+```
+
+[⇧ back to top](#flows-utility-types)
+
+### `$ObjMap<T, F>`
+
+takes an object type `T`, and a function type `F`, and returns the object type obtained by mapping the type of each value in the object with the provided function type `F`
+https://flow.org/en/docs/types/utilities/#toc-objmap
+
+**Usage:**
+
+```ts
+import { $ObjMap } from 'utility-types';
+
+type Obj = {
+  a: number;
+  b?: boolean;
+  c: string | null;
+};
+type Mapper = (value: number | boolean | string | null) => string;
+type MappedObj = $ObjMap<Obj, Mapper>;
+```
+In that case `MappedObj` will be
+
+```ts
+{
+  a: string;
+  b?: string;
+  c: string
+}
 ```
 
 [⇧ back to top](#flows-utility-types)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   $Diff,
   $PropertyType,
   $ElementType,
+  $ObjMap,
 } from './utility-types';
 
 export {

--- a/src/utility-types.spec.ts
+++ b/src/utility-types.spec.ts
@@ -7,6 +7,7 @@ import {
   $Diff,
   $PropertyType,
   $ElementType,
+  $ObjMap,
 } from './';
 
 /**
@@ -103,5 +104,26 @@ describe('utility types', () => {
     type Fn = () => number;
     type FnReturnType = $Call<ExtractReturnType<Fn>>;
     testType<FnReturnType>(4);
+  });
+
+  it('$ObjMap', () => {
+    type Obj = {
+      a: number;
+      b?: boolean;
+      c: string | null;
+    };
+    type Mapper = (value: number | boolean | string | null) => string;
+    // type Nope = (value: number | boolean | null) => string; // Error: Type 'Mapper' does not satisfy the constraint 'ObjMapper<Obj>'
+
+    type MappedObj = $ObjMap<Obj, Mapper>;
+    testType<MappedObj>({
+      a: 'a',
+      c: 'c',
+    });
+    testType<MappedObj>({
+      a: 'a',
+      b: 'b',
+      c: 'c',
+    });
   });
 });

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -59,13 +59,18 @@ export type $Call<Fn extends (...args: any[]) => any> = Fn extends (
   ? RT
   : never;
 
-type ObjMapper<T> = (value: $Values<Required<T>>, ...args: any[]) => any;
+/**
+ * ObjMapper
+ * @desc Mapper function type infered from the object
+ * @private
+ */
+type _ObjMapper<T> = (value: $Values<Required<T>>, ...args: any[]) => any;
 
 /**
  * $ObjMap
  * @desc takes an object type `T`, and a function type `F`, and returns the object type obtained by mapping the type of each value in the object with the provided function type `F`
  * @see https://flow.org/en/docs/types/utilities/#toc-objmap
  */
-export type $ObjMap<T extends object, F extends ObjMapper<T>> = {
+export type $ObjMap<T extends object, F extends _ObjMapper<T>> = {
   [K in keyof T]: ReturnType<F>
 };

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -58,3 +58,14 @@ export type $Call<Fn extends (...args: any[]) => any> = Fn extends (
 ) => infer RT
   ? RT
   : never;
+
+type ObjMapper<T> = (value: $Values<Required<T>>, ...args: any[]) => any;
+
+/**
+ * $ObjMap
+ * @desc takes an object type `T`, and a function type `F`, and returns the object type obtained by mapping the type of each value in the object with the provided function type `F`
+ * @see https://flow.org/en/docs/types/utilities/#toc-objmap
+ */
+export type $ObjMap<T extends object, F extends ObjMapper<T>> = {
+  [K in keyof T]: ReturnType<F>
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "outDir": "out/", // target for compiled files
     "allowSyntheticDefaultImports": true, // no errors on commonjs default import
     "allowJs": false, // include js files
@@ -17,14 +18,11 @@
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
     "pretty": true,
     "removeComments": true,
     "sourceMap": true,
-    "stripInternal": true
+    "stripInternal": true,
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "src/**/*.spec.ts"]


### PR DESCRIPTION
```ts
type ObjMapper<T> = (value: $Values<Required<T>>, ...args: any[]) => any;

export type $ObjMap<T extends object, F extends ObjMapper<T>> = {
  [K in keyof T]: ReturnType<F>
};
```

`$ObjMap` will generate mapper function type from given object type. 

For example if `T` is `{ a: number; b?: string }` the mapper should be 
```ts
(value: number | string, ...args: any[]) => any
```

> Mapper doesn't need to handle `undefined` for optional properties so `undefined` is not included in `value`'s type.

If mapper doesn't match TS will warn for it:

![image](https://user-images.githubusercontent.com/1812118/50100096-94e72800-025a-11e9-9971-001e737b5783.png)

> Must use `--strict` for `tsc`

Fix https://github.com/piotrwitek/utility-types/issues/18