### PR TITLE
fix: FunctionKey and NonFunctionKeys

### DIFF
--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -88,7 +88,7 @@ exports[`Diff testType<Diff<Props, NewProps>>() 1`] = `"Pick<Props, \\"name\\" |
 
 exports[`Falsey testType<Falsey>() 1`] = `"Falsey"`;
 
-exports[`FunctionKeys testType<FunctionKeys<MixedProps>>() 1`] = `"\\"setName\\""`;
+exports[`FunctionKeys testType<FunctionKeys<MixedProps>>() 1`] = `"\\"setName\\" | \\"someFn\\""`;
 
 exports[`Intersection const result: Intersection<T, Omit<T, 'age'>> = rest 1`] = `"any"`;
 
@@ -96,7 +96,7 @@ exports[`Intersection testType<Intersection<Props | NewProps, DefaultProps>>() 1
 
 exports[`Intersection testType<Intersection<Props, DefaultProps>>() 1`] = `"Pick<Props, \\"age\\">"`;
 
-exports[`NonFunctionKeys testType<NonFunctionKeys<MixedProps>>() 1`] = `"\\"name\\""`;
+exports[`NonFunctionKeys testType<NonFunctionKeys<MixedProps>>() 1`] = `"\\"name\\" | \\"someKeys\\""`;
 
 exports[`NonUndefined testType<NonUndefined<string | null | undefined>>() 1`] = `"string | null"`;
 

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -116,13 +116,13 @@ type RequiredOptionalProps = {
 
 // @dts-jest:group FunctionKeys
 {
-  // @dts-jest:pass:snap -> "setName"
+  // @dts-jest:pass:snap -> "setName | someFn "
   testType<FunctionKeys<MixedProps>>();
 }
 
 // @dts-jest:group NonFunctionKeys
 {
-  // @dts-jest:pass:snap -> "name"
+  // @dts-jest:pass:snap -> "name | someKeys"
   testType<NonFunctionKeys<MixedProps>>();
 }
 

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -48,7 +48,12 @@ import {
 type Props = { name: string; age: number; visible: boolean };
 type DefaultProps = { age: number };
 type NewProps = { age: string; other: string };
-type MixedProps = { name: string; setName: (name: string) => void };
+type MixedProps = {
+  name: string;
+  setName: (name: string) => void;
+  someKeys?: string;
+  someFn?: (...args: any) => any;
+};
 type ReadWriteProps = { readonly a: number; b: string };
 type RequiredOptionalProps = {
   req: number;

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -116,13 +116,13 @@ type RequiredOptionalProps = {
 
 // @dts-jest:group FunctionKeys
 {
-  // @dts-jest:pass:snap -> "setName | someFn "
+  // @dts-jest:pass:snap -> "setName" | "someFn"
   testType<FunctionKeys<MixedProps>>();
 }
 
 // @dts-jest:group NonFunctionKeys
 {
-  // @dts-jest:pass:snap -> "name | someKeys"
+  // @dts-jest:pass:snap -> "name" | "someKeys"
   testType<NonFunctionKeys<MixedProps>>();
 }
 

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -48,7 +48,12 @@ import {
 type Props = { name: string; age: number; visible: boolean };
 type DefaultProps = { age: number };
 type NewProps = { age: string; other: string };
-type MixedProps = { name: string; setName: (name: string) => void };
+type MixedProps = {
+  name: string;
+  setName: (name: string) => void;
+  someKeys?: string;
+  someFn?: (...args: any) => any;
+};
 type ReadWriteProps = { readonly a: number; b: string };
 type RequiredOptionalProps = {
   req: number;

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -91,7 +91,7 @@ export type NonUndefined<A> = A extends undefined ? never : A;
  * @example
  *  type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
  *
- *   // Expect: "setName | someFn "
+ *   // Expect: "setName | someFn"
  *   type Keys = FunctionKeys<MixedProps>;
  */
 export type FunctionKeys<T extends object> = {

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -89,26 +89,30 @@ export type NonUndefined<A> = A extends undefined ? never : A;
  * FunctionKeys
  * @desc get union type of keys that are functions in object type `T`
  * @example
- *   type MixedProps = { name: string; setName: (name: string) => void };
+ *  type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
  *
  *   // Expect: "setName"
  *   type Keys = FunctionKeys<MixedProps>;
  */
 export type FunctionKeys<T extends object> = {
-  [K in keyof T]: T[K] extends Function ? K : never
+  [K in keyof T]-?: T[K] extends Function ? K : never
 }[keyof T];
 
 /**
  * NonFunctionKeys
  * @desc get union type of keys that are non-functions in object type `T`
  * @example
- *   type MixedProps = { name: string; setName: (name: string) => void };
+ *   type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
  *
  *   // Expect: "name"
  *   type Keys = NonFunctionKeys<MixedProps>;
  */
 export type NonFunctionKeys<T extends object> = {
-  [K in keyof T]: T[K] extends Function ? never : K
+  [K in keyof T]-?: undefined extends T[K]
+    ? never
+    : T[K] extends Function
+    ? never
+    : K
 }[keyof T];
 
 /**

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -91,11 +91,11 @@ export type NonUndefined<A> = A extends undefined ? never : A;
  * @example
  *  type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
  *
- *   // Expect: "setName"
+ *   // Expect: "setName | someFn "
  *   type Keys = FunctionKeys<MixedProps>;
  */
 export type FunctionKeys<T extends object> = {
-  [K in keyof T]-?: T[K] extends Function ? K : never
+  [K in keyof T]-?: NonUndefined<T[K]> extends Function ? K : never
 }[keyof T];
 
 /**
@@ -104,15 +104,11 @@ export type FunctionKeys<T extends object> = {
  * @example
  *   type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
  *
- *   // Expect: "name"
+ *   // Expect: "name | someKey"
  *   type Keys = NonFunctionKeys<MixedProps>;
  */
 export type NonFunctionKeys<T extends object> = {
-  [K in keyof T]-?: undefined extends T[K]
-    ? never
-    : T[K] extends Function
-    ? never
-    : K
+  [K in keyof T]-?: NonUndefined<T[K]> extends Function ? never : K
 }[keyof T];
 
 /**


### PR DESCRIPTION
#41  Description
FunctionKeys and NonFunctionKeys cant work with optional keys
[example](https://typescript-play.js.org/#code/C4TwDgpgBAYgrgOwMbAJYHsEGkIgM4A8AKlBAB7AQIAmeU6ARgFYQoB8UAvFAN4BQUKAG0sUVAigBrXOgBmUIgF0AXApGLSFKrViIUGCQH4oo1QggA3CACc+AXyHSQchYr59yYdNeBRQkKAA5THhkNEwcfGJNSho6RhZ2Ll4BYVFxKRl5JVUidRjtOlD9TChjcytrKFUse0cs1wBud39oAFlUMghqAAVrdDA6bn5BBABDAFsIVTxga3EAc2bBPAhgQMnpqAAKcamZucWASi4OC3RUamWoPHQpyLxDA-mEJdTbqZgEJ52AOn+xtYFnhVGMECATpwOGCQM07M0+K0TLghrowgYHgQOl1ev1BmxEeBoOYAO6RZLBBDFcLYFFYzrdPoDPBsIA)
```ts
type FunctionKeys<T extends object> = {
  [K in keyof T]: T[K] extends Function ? K : never
}[keyof T]

export type NonFunctionKeys<T extends object> = {
  [K in keyof T]: T[K] extends Function ? never : K
}[keyof T];

type MixedProps = {
  name: string;
  setName: (name: string) => void;
  someKeys?: string;
  someFn?: (...args: any) => any;
};
// "setName" | undefined
type Keys = FunctionKeys<MixedProps>
// "name" | "someKeys" | "someFn" | undefined
type newKey = NonFunctionKeys<MixedProps>
```
## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [x] I have added at least one unit test to confirm the bug have been fixed
* [x] I have checked and updated TOC and API Docs when necessary

