### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ type RequiredProps = Diff<Props, DefaultProps>;
 
 ### `Subtract<T, T1>`
 
-From `T` remove properties that exist in `T1` (`T` is a subtype of `T1`)
+From `T` remove properties that exist in `T1` (`T1` has a subset of the properties of `T`)
 
 **Usage:**
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ type RequiredProps = Diff<Props, DefaultProps>;
 
 ### `Subtract<T, T1>`
 
-From `T` remove properties that exist in `T1` (`T1` is a subtype of `T`)
+From `T` remove properties that exist in `T1` (`T` is a subtype of `T1`)
 
 **Usage:**
 

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -316,7 +316,7 @@ export type Diff<T extends object, U extends object> = Pick<
 
 /**
  * Subtract
- * @desc From `T` remove properties that exist in `T1` (`T1` is a subtype of `T`)
+ * @desc From `T` remove properties that exist in `T1` (`T1` has a subset of the properties of `T`)
  * @example
  *   type Props = { name: string; age: number; visible: boolean };
  *   type DefaultProps = { age: number };


### PR DESCRIPTION
`T` is a subtype of `T1`, not vice versa. `T` has all of the same properties as `T1` and possibly more. `T1` has a subset of the properties of `T`.