### PR TITLE
Add new Required<T, K> as the opposite of Optional<T, K>

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Issues can be funded by anyone and the money will be transparently distributed t
 * [`OptionalKeys<T>`](#optionalkeyst)
 * [`Partial<T>`](#partialt) _(built-in)_
 * [`DeepPartial<T>`](#deeppartialt)
-* [`Required<T>`](#requiredt) _(built-in)_
+* [`Required<T, K>`](#requiredt)
 * [`DeepRequired<T>`](#deeprequiredt)
 * [`Readonly<T>`](#readonlyt) _(built-in)_
 * [`DeepReadonly<T>`](#deepreadonlyt)
@@ -621,9 +621,22 @@ Make all properties of object type optional
 
 [⇧ back to top](#table-of-contents)
 
-### `Required<T>`
+### `Required<T, K>`
 
-Make all properties of object type non-optional
+From `T` make a set of properties by key `K` become required
+
+**Usage:**
+
+```ts
+import { Required } from 'utility-types';
+
+type Props = { name?: string; age?: number; visible?: boolean; };
+
+// Expect: { name: string; age: number; visible: boolean; }
+type Props = Required<Props>
+// Expect: { name?: string; age: number; visible: boolean; }
+type Props = Required<Props, 'age' | 'visible'>;
+```
 
 [⇧ back to top](#table-of-contents)
 

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -4,6 +4,17 @@ exports[`Assign const result: Assign<{}, Omit<T, 'age'>> = rest 1`] = `"any"`;
 
 exports[`Assign testType<Assign<Props, NewProps>>() 1`] = `"Pick<Pick<Props, \\"name\\" | \\"visible\\"> & Pick<NewProps, \\"age\\"> & Pick<NewProps, \\"other\\">, \\"name\\" | \\"age\\" | \\"visible\\" | \\"other\\">"`;
 
+exports[`AugmentedRequired testType<AugmentedRequired<Partial<Props>, 'age' | 'visible'>>({
+      age: 99,
+      visible: true,
+    }) 1`] = `"AugmentedRequired<Partial<Props>, \\"age\\" | \\"visible\\">"`;
+
+exports[`AugmentedRequired testType<AugmentedRequired<Partial<Props>>>({
+      name: 'Yolo',
+      age: 99,
+      visible: true,
+    }) 1`] = `"AugmentedRequired<Partial<Props>, \\"name\\" | \\"age\\" | \\"visible\\">"`;
+
 exports[`Brand testType<Brand<number, 'USD'>>() 1`] = `"Brand<number, \\"USD\\">"`;
 
 exports[`DeepNonNullable testType<
@@ -161,13 +172,6 @@ exports[`Primitive testType<Primitive>() 1`] = `"Primitive"`;
 exports[`PromiseType testType<PromiseType<Promise<string>>>() 1`] = `"string"`;
 
 exports[`ReadonlyKeys testType<ReadonlyKeys<ReadWriteProps>>() 1`] = `"\\"a\\""`;
-
-exports[`Required testType<Required<Partial<Props>, 'age' | 'visible'>>({
-      age: 99,
-      visible: true,
-    }) 1`] = `"Required<Partial<Props>, \\"age\\" | \\"visible\\">"`;
-
-exports[`Required testType<Required<Partial<Props>>>({ name: 'Yolo', age: 99, visible: true }) 1`] = `"Required<Partial<Props>, \\"name\\" | \\"age\\" | \\"visible\\">"`;
 
 exports[`RequiredKeys testType<RequiredKeys<RequiredOptionalProps>>() 1`] = `"\\"req\\" | \\"reqUndef\\""`;
 

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -162,6 +162,13 @@ exports[`PromiseType testType<PromiseType<Promise<string>>>() 1`] = `"string"`;
 
 exports[`ReadonlyKeys testType<ReadonlyKeys<ReadWriteProps>>() 1`] = `"\\"a\\""`;
 
+exports[`Required testType<Required<Partial<Props>, 'age' | 'visible'>>({
+      age: 99,
+      visible: true,
+    }) 1`] = `"Required<Partial<Props>, \\"age\\" | \\"visible\\">"`;
+
+exports[`Required testType<Required<Partial<Props>>>({ name: 'Yolo', age: 99, visible: true }) 1`] = `"Required<Partial<Props>, \\"name\\" | \\"age\\" | \\"visible\\">"`;
+
 exports[`RequiredKeys testType<RequiredKeys<RequiredOptionalProps>>() 1`] = `"\\"req\\" | \\"reqUndef\\""`;
 
 exports[`SetComplement testType<SetComplement<'1' | '2' | '3', '2' | '3'>>() 1`] = `"\\"1\\""`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export {
   Unionize,
   ValuesType,
   WritableKeys,
+  AugmentedRequired as Required,
 } from './mapped-types';
 
 export * from './type-guards';

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -40,7 +40,7 @@ import {
   OmitByValueExact,
   Optional,
   ValuesType,
-  Required,
+  AugmentedRequired,
 } from './mapped-types';
 
 /**
@@ -529,13 +529,17 @@ type RequiredOptionalProps = {
   testType<ValuesType<Uint32Array>>();
 }
 
-// @dts-jest:group Required
+// @dts-jest:group AugmentedRequired
 {
-  // @dts-jest:pass:snap -> Required<Partial<Props>, "name" | "age" | "visible">
-  testType<Required<Partial<Props>>>({ name: 'Yolo', age: 99, visible: true });
+  // @dts-jest:pass:snap -> AugmentedRequired<Partial<Props>, "name" | "age" | "visible">
+  testType<AugmentedRequired<Partial<Props>>>({
+    name: 'Yolo',
+    age: 99,
+    visible: true,
+  });
 
-  // @dts-jest:pass:snap -> Required<Partial<Props>, "age" | "visible">
-  testType<Required<Partial<Props>, 'age' | 'visible'>>({
+  // @dts-jest:pass:snap -> AugmentedRequired<Partial<Props>, "age" | "visible">
+  testType<AugmentedRequired<Partial<Props>, 'age' | 'visible'>>({
     age: 99,
     visible: true,
   });

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -40,6 +40,7 @@ import {
   OmitByValueExact,
   Optional,
   ValuesType,
+  Required,
 } from './mapped-types';
 
 /**
@@ -526,4 +527,16 @@ type RequiredOptionalProps = {
   testType<ValuesType<Uint16Array>>();
   // @dts-jest:pass:snap -> number
   testType<ValuesType<Uint32Array>>();
+}
+
+// @dts-jest:group Required
+{
+  // @dts-jest:pass:snap -> Required<Partial<Props>, "name" | "age" | "visible">
+  testType<Required<Partial<Props>>>({ name: 'Yolo', age: 99, visible: true });
+
+  // @dts-jest:pass:snap -> Required<Partial<Props>, "age" | "visible">
+  testType<Required<Partial<Props>, 'age' | 'visible'>>({
+    age: 99,
+    visible: true,
+  });
 }

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -40,6 +40,7 @@ import {
   OmitByValueExact,
   Optional,
   ValuesType,
+  Required,
 } from './mapped-types';
 
 /**
@@ -526,4 +527,16 @@ type RequiredOptionalProps = {
   testType<ValuesType<Uint16Array>>();
   // @dts-jest:pass:snap
   testType<ValuesType<Uint32Array>>();
+}
+
+// @dts-jest:group Required
+{
+  // @dts-jest:pass:snap
+  testType<Required<Partial<Props>>>({ name: 'Yolo', age: 99, visible: true });
+
+  // @dts-jest:pass:snap
+  testType<Required<Partial<Props>, 'age' | 'visible'>>({
+    age: 99,
+    visible: true,
+  });
 }

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -40,7 +40,7 @@ import {
   OmitByValueExact,
   Optional,
   ValuesType,
-  Required,
+  AugmentedRequired,
 } from './mapped-types';
 
 /**
@@ -529,13 +529,17 @@ type RequiredOptionalProps = {
   testType<ValuesType<Uint32Array>>();
 }
 
-// @dts-jest:group Required
+// @dts-jest:group AugmentedRequired
 {
   // @dts-jest:pass:snap
-  testType<Required<Partial<Props>>>({ name: 'Yolo', age: 99, visible: true });
+  testType<AugmentedRequired<Partial<Props>>>({
+    name: 'Yolo',
+    age: 99,
+    visible: true,
+  });
 
   // @dts-jest:pass:snap
-  testType<Required<Partial<Props>, 'age' | 'visible'>>({
+  testType<AugmentedRequired<Partial<Props>, 'age' | 'visible'>>({
     age: 99,
     visible: true,
   });

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -631,9 +631,7 @@ export type ValuesType<
  *    // Expect: { name?: string; age: number; visible: boolean; }
  *    type Props = Required<Props, 'age' | 'visible'>;
  */
-type AugmentedRequired<T extends object, K extends keyof T = keyof T> = Omit<
-  T,
-  K
-> &
-  Required<Pick<T, K>>;
-export { AugmentedRequired as Required };
+export type AugmentedRequired<
+  T extends object,
+  K extends keyof T = keyof T
+> = Omit<T, K> & Required<Pick<T, K>>;

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -615,9 +615,6 @@ export type ValuesType<
   ? T[keyof T]
   : never;
 
-// Copy of builtin Required to make definition of custom Required simpler
-type RequiredCopy<T> = { [P in keyof T]-?: T[P] };
-
 /**
  * Required
  * @desc From `T` make a set of properties by key `K` become required
@@ -634,8 +631,9 @@ type RequiredCopy<T> = { [P in keyof T]-?: T[P] };
  *    // Expect: { name?: string; age: number; visible: boolean; }
  *    type Props = Required<Props, 'age' | 'visible'>;
  */
-export type Required<T extends object, K extends keyof T = keyof T> = Omit<
+type AugmentedRequired<T extends object, K extends keyof T = keyof T> = Omit<
   T,
   K
 > &
-  RequiredCopy<Pick<T, K>>;
+  Required<Pick<T, K>>;
+export { AugmentedRequired as Required };

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -614,3 +614,28 @@ export type ValuesType<
   : T extends object
   ? T[keyof T]
   : never;
+
+// Copy of builtin Required to make definition of custom Required simpler
+type RequiredCopy<T> = { [P in keyof T]-?: T[P] };
+
+/**
+ * Required
+ * @desc From `T` make a set of properties by key `K` become required
+ * @example
+ *    type Props = {
+ *      name?: string;
+ *      age?: number;
+ *      visible?: boolean;
+ *    };
+ *
+ *    // Expect: { name: string; age: number; visible: boolean; }
+ *    type Props = Required<Props>;
+ *
+ *    // Expect: { name?: string; age: number; visible: boolean; }
+ *    type Props = Required<Props, 'age' | 'visible'>;
+ */
+export type Required<T extends object, K extends keyof T = keyof T> = Omit<
+  T,
+  K
+> &
+  RequiredCopy<Pick<T, K>>;


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
Adds a new type Required<T, K> that makes keys K in type T required (default keyof T). Compatible with the built-in Required type.

Credit to @vhenzl for the basic implementation.

## Related issues:
- Resolved #93

## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
* [x] I have linked all related issues above
* [ ] I have rebased my branch

For new features:
* [x] I have added entry in TOC and API Docs
* [x] I have added a short example in API Docs to demonstrate new usage
* [x] I have added type unit tests with `dts-jest`
