### PR TITLE
adds SEO content for Brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ type PartialNestedProps = DeepPartial<NestedProps>;
 
 ### `Brand<T, U>`
 
-Define nominal type of `U` based on type of `T`.
+Define nominal type of `U` based on type of `T`. Similar to Opaque types in Flow.
 
 **Usage:**
 

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -535,7 +535,7 @@ export type _DeepPartialObject<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 
 /**
  * Brand
- * @desc Define nominal type of U based on type of T.
+ * @desc Define nominal type of U based on type of T. Similar to Opaque types in Flow.
  * @example
  *   type USD = Brand<number, "USD">
  *   type EUR = Brand<number, "EUR">


### PR DESCRIPTION
I also noticed that `Exact` doesn't seem to be in the README.md (because I was going to add this same line to Exact's description).  Is this intended?