### PR TITLE
Fix link and typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Issues can be funded by anyone and the money will be transparently distributed t
 * [`OptionalKeys<T>`](#optionalkeyst)
 * [`Partial<T>`](#partialt) _(built-in)_
 * [`DeepPartial<T>`](#deeppartialt)
-* [`Required<T, K>`](#requiredt)
+* [`Required<T, K>`](#requiredt-k)
 * [`DeepRequired<T>`](#deeprequiredt)
 * [`Readonly<T>`](#readonlyt) _(built-in)_
 * [`DeepReadonly<T>`](#deepreadonlyt)

--- a/README.md
+++ b/README.md
@@ -353,12 +353,12 @@ From `T` make a set of properties by key `K` become optional
 ```ts
 import { Optional } from 'utility-types';
 
-type Props = { name: string; age: number; visilbe: boolean; };
+type Props = { name: string; age: number; visible: boolean; };
 
-// Expect: { name?: string; age?: number; visilbe?: boolean; }
+// Expect: { name?: string; age?: number; visible?: boolean; }
 type Props = Optional<Props>
-// Expect: { name: string; age?: number; visilbe?: boolean; }
-type Props = Optional<Props, 'age' | 'visilbe'>;
+// Expect: { name: string; age?: number; visible?: boolean; }
+type Props = Optional<Props, 'age' | 'visible'>;
 ```
 
 [⇧ back to top](#table-of-contents)


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
The URL hash for Required changed when a type parameter was added breaking the link in the TOC. While I was there I noticed a typo in the in the Optional example and fixed it.
