### PR TITLE
Fix typo in ValuesType with flow syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,19 +593,19 @@ import { ValuesType } from 'utility-types';
 
 type Props = { name: string; age: number; visible: boolean };
 // Expect: string | number | boolean
-type PropsValues = $ValuesType<Props>;
+type PropsValues = ValuesType<Props>;
 
 type NumberArray = number[];
 // Expect: number
-type NumberItems = $ValuesType<NumberArray>;
+type NumberItems = ValuesType<NumberArray>;
 
 type ReadonlyNumberTuple = readonly [1, 2];
 // Expect: 1 | 2
-type AnotherNumberUnion = $ValuesType<NumberTuple>;
+type AnotherNumberUnion = ValuesType<NumberTuple>;
 
 type BinaryArray = Uint8Array;
 // Expect: number
-type BinaryItems = $ValuesType<BinaryArray>;
+type BinaryItems = ValuesType<BinaryArray>;
 ```
 
 [⇧ back to top](#table-of-contents)


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
There is Flow typing syntax In TypeScript example of `ValuesType`

## Related issues:
- Resolved #104

## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
* [x] I have linked all related issues above
* [ ] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
