### PR TITLE
Make applying DeepReadonly idempotent

### DIFF
--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -57,7 +57,7 @@ exports[`DeepPartial testType<typeof partialNested.first>() 1`] = `"_DeepPartial
 
 exports[`DeepPartial testType<typeof second>() 1`] = `"_DeepPartialObject<{ name: string; }> | undefined"`;
 
-exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>() 1`] = `"_DeepReadonlyArray<_DeepReadonlyObject<{ name: string; }>>"`;
+exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>() 1`] = `"_DeepReadonlyArray<{ name: string; }>"`;
 
 exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']>() 1`] = `"_DeepReadonlyObject<{ second: { name: string; }[]; }>"`;
 

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -57,6 +57,8 @@ exports[`DeepPartial testType<typeof partialNested.first>() 1`] = `"_DeepPartial
 
 exports[`DeepPartial testType<typeof second>() 1`] = `"_DeepPartialObject<{ name: string; }> | undefined"`;
 
+exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>() 1`] = `"_DeepReadonlyArray<_DeepReadonlyObject<{ name: string; }>>"`;
+
 exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']>() 1`] = `"_DeepReadonlyObject<{ second: { name: string; }[]; }>"`;
 
 exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']['second']>() 1`] = `"_DeepReadonlyArray<{ name: string; }>"`;

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -57,9 +57,13 @@ exports[`DeepPartial testType<typeof partialNested.first>() 1`] = `"_DeepPartial
 
 exports[`DeepPartial testType<typeof second>() 1`] = `"_DeepPartialObject<{ name: string; }> | undefined"`;
 
-exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>() 1`] = `"_DeepReadonlyArray<{ name: string; }>"`;
+exports[`DeepReadonly testType<
+      DeepReadonly<string | null | undefined | boolean | number | bigint | symbol>
+    >() 1`] = `"string | number | bigint | boolean | symbol | null | undefined"`;
 
-exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedProps>['first']>>() 1`] = `"_DeepReadonlyObject<{ second: { name: string; }; }>"`;
+exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>>() 1`] = `"_DeepReadonlyObject<{ first: { second: { name: string; }[]; }; }>"`;
+
+exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedProps>>>() 1`] = `"_DeepReadonlyObject<{ first: { second: { name: string; }; }; }>"`;
 
 exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']>() 1`] = `"_DeepReadonlyObject<{ second: { name: string; }[]; }>"`;
 

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -59,6 +59,8 @@ exports[`DeepPartial testType<typeof second>() 1`] = `"_DeepPartialObject<{ name
 
 exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>() 1`] = `"_DeepReadonlyArray<{ name: string; }>"`;
 
+exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedProps>['first']>>() 1`] = `"_DeepReadonlyObject<{ second: { name: string; }; }>"`;
+
 exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']>() 1`] = `"_DeepReadonlyObject<{ second: { name: string; }[]; }>"`;
 
 exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']['second']>() 1`] = `"_DeepReadonlyArray<{ name: string; }>"`;

--- a/src/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__snapshots__/utility-types.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`$PropertyType testType<$PropertyType<[boolean, number], '1'>>() 1`] = `
 
 exports[`$PropertyType testType<$PropertyType<Props, 'name'>>() 1`] = `"string"`;
 
-exports[`$ReadOnly testType<$ReadOnly<Props>>() 1`] = `"_DeepReadonlyObject<Props>"`;
+exports[`$ReadOnly testType<$ReadOnly<Props>>() 1`] = `"_DeepReadonlyObject<{ name: string; age: number; visible: boolean; }>"`;
 
 exports[`$Shape testType<$Shape<Props>>() 1`] = `"Partial<Props>"`;
 

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -328,6 +328,8 @@ type RequiredOptionalProps = {
   testType<DeepReadonly<NestedArrayProps>['first']>();
   // @dts-jest:pass:snap -> _DeepReadonlyArray<{ name: string; }>
   testType<DeepReadonly<NestedArrayProps>['first']['second']>();
+  // @dts-jest:pass:snap -> _DeepReadonlyArray<_DeepReadonlyObject<{ name: string; }>>
+  testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>();
   // @dts-jest:pass:snap -> string
   testType<DeepReadonly<NestedArrayProps>['first']['second'][number]['name']>();
 

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -314,8 +314,6 @@ type RequiredOptionalProps = {
   };
   // @dts-jest:pass:snap -> _DeepReadonlyObject<{ second: { name: string; }; }>
   testType<DeepReadonly<NestedProps>['first']>();
-  // @dts-jest:pass:snap -> _DeepReadonlyObject<{ second: { name: string; }; }>
-  testType<DeepReadonly<DeepReadonly<NestedProps>['first']>>();
   // @dts-jest:pass:snap -> _DeepReadonlyObject<{ name: string; }>
   testType<DeepReadonly<NestedProps>['first']['second']>();
   // @dts-jest:pass:snap -> string
@@ -330,8 +328,6 @@ type RequiredOptionalProps = {
   testType<DeepReadonly<NestedArrayProps>['first']>();
   // @dts-jest:pass:snap -> _DeepReadonlyArray<{ name: string; }>
   testType<DeepReadonly<NestedArrayProps>['first']['second']>();
-  // @dts-jest:pass:snap -> _DeepReadonlyArray<{ name: string; }>
-  testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>();
   // @dts-jest:pass:snap -> string
   testType<DeepReadonly<NestedArrayProps>['first']['second'][number]['name']>();
 
@@ -346,6 +342,16 @@ type RequiredOptionalProps = {
   testType<DeepReadonly<NestedFunctionProps>['first']['second']>();
   // @dts-jest:pass:snap -> string
   testType<ReturnType<DeepReadonly<NestedFunctionProps>['first']['second']>>();
+
+  // @dts-jest:pass:snap -> _DeepReadonlyObject<{ first: { second: { name: string; }; }; }>
+  testType<DeepReadonly<DeepReadonly<NestedProps>>>();
+  // @dts-jest:pass:snap -> _DeepReadonlyObject<{ first: { second: { name: string; }[]; }; }>
+  testType<DeepReadonly<DeepReadonly<NestedArrayProps>>>();
+
+  // @dts-jest:pass:snap -> string | number | bigint | boolean | symbol | null | undefined
+  testType<
+    DeepReadonly<string | null | undefined | boolean | number | bigint | symbol>
+  >();
 }
 
 // @dts-jest:group DeepRequired

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -328,7 +328,7 @@ type RequiredOptionalProps = {
   testType<DeepReadonly<NestedArrayProps>['first']>();
   // @dts-jest:pass:snap -> _DeepReadonlyArray<{ name: string; }>
   testType<DeepReadonly<NestedArrayProps>['first']['second']>();
-  // @dts-jest:pass:snap -> _DeepReadonlyArray<_DeepReadonlyObject<{ name: string; }>>
+  // @dts-jest:pass:snap -> _DeepReadonlyArray<{ name: string; }>
   testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>();
   // @dts-jest:pass:snap -> string
   testType<DeepReadonly<NestedArrayProps>['first']['second'][number]['name']>();

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -314,6 +314,8 @@ type RequiredOptionalProps = {
   };
   // @dts-jest:pass:snap -> _DeepReadonlyObject<{ second: { name: string; }; }>
   testType<DeepReadonly<NestedProps>['first']>();
+  // @dts-jest:pass:snap -> _DeepReadonlyObject<{ second: { name: string; }; }>
+  testType<DeepReadonly<DeepReadonly<NestedProps>['first']>>();
   // @dts-jest:pass:snap -> _DeepReadonlyObject<{ name: string; }>
   testType<DeepReadonly<NestedProps>['first']['second']>();
   // @dts-jest:pass:snap -> string

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -315,8 +315,6 @@ type RequiredOptionalProps = {
   // @dts-jest:pass:snap
   testType<DeepReadonly<NestedProps>['first']>();
   // @dts-jest:pass:snap
-  testType<DeepReadonly<DeepReadonly<NestedProps>['first']>>();
-  // @dts-jest:pass:snap
   testType<DeepReadonly<NestedProps>['first']['second']>();
   // @dts-jest:pass:snap
   testType<DeepReadonly<NestedProps>['first']['second']['name']>();
@@ -331,8 +329,6 @@ type RequiredOptionalProps = {
   // @dts-jest:pass:snap
   testType<DeepReadonly<NestedArrayProps>['first']['second']>();
   // @dts-jest:pass:snap
-  testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>();
-  // @dts-jest:pass:snap
   testType<DeepReadonly<NestedArrayProps>['first']['second'][number]['name']>();
 
   type NestedFunctionProps = {
@@ -346,6 +342,16 @@ type RequiredOptionalProps = {
   testType<DeepReadonly<NestedFunctionProps>['first']['second']>();
   // @dts-jest:pass:snap
   testType<ReturnType<DeepReadonly<NestedFunctionProps>['first']['second']>>();
+
+  // @dts-jest:pass:snap
+  testType<DeepReadonly<DeepReadonly<NestedProps>>>();
+  // @dts-jest:pass:snap
+  testType<DeepReadonly<DeepReadonly<NestedArrayProps>>>();
+
+  // @dts-jest:pass:snap
+  testType<
+    DeepReadonly<string | null | undefined | boolean | number | bigint | symbol>
+  >();
 }
 
 // @dts-jest:group DeepRequired

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -315,6 +315,8 @@ type RequiredOptionalProps = {
   // @dts-jest:pass:snap
   testType<DeepReadonly<NestedProps>['first']>();
   // @dts-jest:pass:snap
+  testType<DeepReadonly<DeepReadonly<NestedProps>['first']>>();
+  // @dts-jest:pass:snap
   testType<DeepReadonly<NestedProps>['first']['second']>();
   // @dts-jest:pass:snap
   testType<DeepReadonly<NestedProps>['first']['second']['name']>();

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -329,6 +329,8 @@ type RequiredOptionalProps = {
   // @dts-jest:pass:snap
   testType<DeepReadonly<NestedArrayProps>['first']['second']>();
   // @dts-jest:pass:snap
+  testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>();
+  // @dts-jest:pass:snap
   testType<DeepReadonly<NestedArrayProps>['first']['second'][number]['name']>();
 
   type NestedFunctionProps = {

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -414,7 +414,7 @@ export type PromiseType<T extends Promise<any>> = T extends Promise<infer U>
  */
 export type DeepReadonly<T> = T extends (...args: any[]) => any
   ? T
-  : T extends any[]
+  : T extends ReadonlyArray<any>
   ? _DeepReadonlyArray<T[number]>
   : T extends object
   ? _DeepReadonlyObject<T>

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -412,25 +412,26 @@ export type PromiseType<T extends Promise<any>> = T extends Promise<infer U>
  *   };
  *   type ReadonlyNestedProps = DeepReadonly<NestedProps>;
  */
-declare const __deepReadonly: unique symbol;
 export type DeepReadonly<T> = T extends
   | ((...args: any[]) => any)
-  | { readonly __deepReadonly?: typeof __deepReadonly }
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
   ? T
-  : T extends ReadonlyArray<any>
-  ? _DeepReadonlyArray<T[number]>
-  : T extends object
-  ? _DeepReadonlyObject<T>
+  : T extends _DeepReadonlyArray<infer U>
+  ? _DeepReadonlyArray<U>
+  : T extends _DeepReadonlyObject<infer V>
+  ? _DeepReadonlyObject<V>
   : T;
 /** @private */
 // tslint:disable-next-line:class-name
-export interface _DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {
-  readonly __deepReadonly?: typeof __deepReadonly;
-}
+export interface _DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
 /** @private */
 export type _DeepReadonlyObject<T> = {
   readonly [P in keyof T]: DeepReadonly<T[P]>
-} & { readonly __deepReadonly?: typeof __deepReadonly };
+};
 
 /**
  * DeepRequired

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -412,13 +412,7 @@ export type PromiseType<T extends Promise<any>> = T extends Promise<infer U>
  *   };
  *   type ReadonlyNestedProps = DeepReadonly<NestedProps>;
  */
-export type DeepReadonly<T> = T extends
-  | ((...args: any[]) => any)
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
+export type DeepReadonly<T> = T extends ((...args: any[]) => any) | Primitive
   ? T
   : T extends _DeepReadonlyArray<infer U>
   ? _DeepReadonlyArray<U>

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -412,7 +412,10 @@ export type PromiseType<T extends Promise<any>> = T extends Promise<infer U>
  *   };
  *   type ReadonlyNestedProps = DeepReadonly<NestedProps>;
  */
-export type DeepReadonly<T> = T extends (...args: any[]) => any
+declare const __deepReadonly: unique symbol;
+export type DeepReadonly<T> = T extends
+  | ((...args: any[]) => any)
+  | { readonly __deepReadonly?: typeof __deepReadonly }
   ? T
   : T extends ReadonlyArray<any>
   ? _DeepReadonlyArray<T[number]>
@@ -421,11 +424,13 @@ export type DeepReadonly<T> = T extends (...args: any[]) => any
   : T;
 /** @private */
 // tslint:disable-next-line:class-name
-export interface _DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
+export interface _DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {
+  readonly __deepReadonly?: typeof __deepReadonly;
+}
 /** @private */
 export type _DeepReadonlyObject<T> = {
   readonly [P in keyof T]: DeepReadonly<T[P]>
-};
+} & { readonly __deepReadonly?: typeof __deepReadonly };
 
 /**
  * DeepRequired

--- a/src/utility-types.spec.snap.ts
+++ b/src/utility-types.spec.snap.ts
@@ -40,7 +40,7 @@ it('$Values', () => {
 
 // @dts-jest:group $ReadOnly
 it('$ReadOnly', () => {
-  // @dts-jest:pass:snap -> _DeepReadonlyObject<Props>
+  // @dts-jest:pass:snap -> _DeepReadonlyObject<{ name: string; age: number; visible: boolean; }>
   testType<$ReadOnly<Props>>();
 });
 


### PR DESCRIPTION
fixes #106

This isn't as clean as I'd like—ideally a recursive application would have no impact. For example, the newly added test would match as if it weren't applied twice:

```
exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>['first']['second']>() 1`] = `"_DeepReadonlyArray<_DeepReadonlyObject<{ name: string; }>>"`;
```

Above, the `_DeepReadonlyObject` is superfluous and isn't there if applied only once.

```
exports[`DeepReadonly testType<DeepReadonly<NestedArrayProps>['first']['second']>() 1`] = `"_DeepReadonlyArray<{ name: string; }>"`;
```

<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->

## Related issues:
- Resolved #106

## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [x] I have added at least one unit test to confirm the bug have been fixed
* [x] I have checked and updated TOC and API Docs when necessary

For new features:
* [x] I have added entry in TOC and API Docs
* [x] I have added a short example in API Docs to demonstrate new usage
* [x] I have added type unit tests with `dts-jest`
