### PR TITLE
Remove `undefined` from `keyof` result of (Pick|Omit)ByValue(Exact)?

### DIFF
--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -139,25 +139,25 @@ exports[`Omit testType<Omit<Props, 'age'>>() (type) should match snapshot 1`] = 
 
 exports[`Omit testType<Omit<T, 'age'>>() (type) should match snapshot 1`] = `"Pick<T, SetDifference<keyof T, \\"age\\">>"`;
 
-exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"opt\\" | \\"optUndef\\" | undefined>"`;
+exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"opt\\" | \\"optUndef\\">"`;
 
-exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
+exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\">"`;
 
-exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
+exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\">"`;
 
-exports[`OmitByValue testType<OmitByValue<T, string | boolean>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: T[Key] extends string | boolean ? never : Key; }[keyof T]>"`;
+exports[`OmitByValue testType<OmitByValue<T, string | boolean>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]-?: T[Key] extends string | boolean ? never : Key; }[keyof T]>"`;
 
-exports[`OmitByValue testType<keyof OmitByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined"`;
+exports[`OmitByValue testType<keyof OmitByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"reqUndef\\" | \\"opt\\" | \\"optUndef\\""`;
 
-exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
+exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"opt\\" | \\"optUndef\\">"`;
 
-exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
+exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\">"`;
 
-exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
+exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\">"`;
 
-exports[`OmitByValueExact testType<OmitByValueExact<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? never : Key : Key; }[keyof T]>"`;
+exports[`OmitByValueExact testType<OmitByValueExact<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]-?: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? never : Key : Key; }[keyof T]>"`;
 
-exports[`OmitByValueExact testType<keyof OmitByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined"`;
+exports[`OmitByValueExact testType<keyof OmitByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"reqUndef\\" | \\"opt\\" | \\"optUndef\\""`;
 
 exports[`Optional testType<Optional<Props, 'age' | 'visible'>>({ name: 'Yolo' }) (type) should match snapshot 1`] = `"Optional<Props, \\"age\\" | \\"visible\\">"`;
 
@@ -173,25 +173,25 @@ exports[`Overwrite const result: Overwrite<Omit<T, 'age'>, T> = rest (type) shou
 
 exports[`Overwrite testType<Overwrite<Props, NewProps>>() (type) should match snapshot 1`] = `"Pick<Pick<Props, \\"name\\" | \\"visible\\"> & Pick<NewProps, \\"age\\">, \\"name\\" | \\"age\\" | \\"visible\\">"`;
 
-exports[`PickByValue testType<PickByValue<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\" | undefined>"`;
+exports[`PickByValue testType<PickByValue<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\">"`;
 
-exports[`PickByValue testType<PickByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | undefined>"`;
+exports[`PickByValue testType<PickByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\">"`;
 
-exports[`PickByValue testType<PickByValue<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, undefined>"`;
+exports[`PickByValue testType<PickByValue<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, never>"`;
 
-exports[`PickByValue testType<PickByValue<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: T[Key] extends number ? Key : never; }[keyof T]>"`;
+exports[`PickByValue testType<PickByValue<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]-?: T[Key] extends number ? Key : never; }[keyof T]>"`;
 
-exports[`PickByValue testType<keyof PickByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"req\\" | undefined"`;
+exports[`PickByValue testType<keyof PickByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"req\\""`;
 
-exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | undefined>"`;
+exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\">"`;
 
-exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | undefined>"`;
+exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\">"`;
 
-exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, undefined>"`;
+exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, never>"`;
 
-exports[`PickByValueExact testType<PickByValueExact<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? Key : never : never; }[keyof T]>"`;
+exports[`PickByValueExact testType<PickByValueExact<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]-?: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? Key : never : never; }[keyof T]>"`;
 
-exports[`PickByValueExact testType<keyof PickByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"req\\" | undefined"`;
+exports[`PickByValueExact testType<keyof PickByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"req\\""`;
 
 exports[`PromiseType testType<PromiseType<Promise<string>>>() (type) should match snapshot 1`] = `"string"`;
 

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -147,6 +147,8 @@ exports[`OmitByValue testType<OmitByValue<RequiredOptionalProps, undefined>>() (
 
 exports[`OmitByValue testType<OmitByValue<T, string | boolean>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: T[Key] extends string | boolean ? never : Key; }[keyof T]>"`;
 
+exports[`OmitByValue testType<keyof OmitByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined"`;
+
 exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
 
 exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
@@ -154,6 +156,8 @@ exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, numbe
 exports[`OmitByValueExact testType<OmitByValueExact<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | \\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined>"`;
 
 exports[`OmitByValueExact testType<OmitByValueExact<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? never : Key : Key; }[keyof T]>"`;
+
+exports[`OmitByValueExact testType<keyof OmitByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"reqUndef\\" | \\"opt\\" | \\"optUndef\\" | undefined"`;
 
 exports[`Optional testType<Optional<Props, 'age' | 'visible'>>({ name: 'Yolo' }) (type) should match snapshot 1`] = `"Optional<Props, \\"age\\" | \\"visible\\">"`;
 
@@ -177,6 +181,8 @@ exports[`PickByValue testType<PickByValue<RequiredOptionalProps, undefined>>() (
 
 exports[`PickByValue testType<PickByValue<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: T[Key] extends number ? Key : never; }[keyof T]>"`;
 
+exports[`PickByValue testType<keyof PickByValue<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"req\\" | undefined"`;
+
 exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, number | undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"reqUndef\\" | undefined>"`;
 
 exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, \\"req\\" | undefined>"`;
@@ -184,6 +190,8 @@ exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, numbe
 exports[`PickByValueExact testType<PickByValueExact<RequiredOptionalProps, undefined>>() (type) should match snapshot 1`] = `"Pick<RequiredOptionalProps, undefined>"`;
 
 exports[`PickByValueExact testType<PickByValueExact<T, number>>() (type) should match snapshot 1`] = `"Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? Key : never : never; }[keyof T]>"`;
+
+exports[`PickByValueExact testType<keyof PickByValueExact<RequiredOptionalProps, number>>() (type) should match snapshot 1`] = `"\\"req\\" | undefined"`;
 
 exports[`PromiseType testType<PromiseType<Promise<string>>>() (type) should match snapshot 1`] = `"string"`;
 

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -142,34 +142,34 @@ type RequiredOptionalProps = {
 
 // @dts-jest:group PickByValue
 {
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req">
   testType<PickByValue<RequiredOptionalProps, number>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef">
   testType<PickByValue<RequiredOptionalProps, number | undefined>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, never>
   testType<PickByValue<RequiredOptionalProps, undefined>>();
-  // @dts-jest:pass:snap -> "req" | undefined
+  // @dts-jest:pass:snap -> "req"
   testType<keyof PickByValue<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
-    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: T[Key] extends number ? Key : never; }[keyof T]>
+    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]-?: T[Key] extends number ? Key : never; }[keyof T]>
     testType<PickByValue<T, number>>();
   };
 }
 
 // @dts-jest:group PickByValueExact
 {
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req">
   testType<PickByValueExact<RequiredOptionalProps, number>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "reqUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "reqUndef">
   testType<PickByValueExact<RequiredOptionalProps, number | undefined>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, never>
   testType<PickByValueExact<RequiredOptionalProps, undefined>>();
-  // @dts-jest:pass:snap -> "req" | undefined
+  // @dts-jest:pass:snap -> "req"
   testType<keyof PickByValueExact<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
-    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? Key : never : never; }[keyof T]>
+    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]-?: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? Key : never : never; }[keyof T]>
     testType<PickByValueExact<T, number>>();
   };
 }
@@ -193,34 +193,34 @@ type RequiredOptionalProps = {
 
 // @dts-jest:group OmitByValue
 {
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "reqUndef" | "opt" | "optUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "reqUndef" | "opt" | "optUndef">
   testType<OmitByValue<RequiredOptionalProps, number>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "opt" | "optUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "opt" | "optUndef">
   testType<OmitByValue<RequiredOptionalProps, number | undefined>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | "opt" | "optUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | "opt" | "optUndef">
   testType<OmitByValue<RequiredOptionalProps, undefined>>();
-  // @dts-jest:pass:snap -> "reqUndef" | "opt" | "optUndef" | undefined
+  // @dts-jest:pass:snap -> "reqUndef" | "opt" | "optUndef"
   testType<keyof OmitByValue<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
-    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: T[Key] extends string | boolean ? never : Key; }[keyof T]>
+    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]-?: T[Key] extends string | boolean ? never : Key; }[keyof T]>
     testType<OmitByValue<T, string | boolean>>();
   };
 }
 
 // @dts-jest:group OmitByValueExact
 {
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "reqUndef" | "opt" | "optUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "reqUndef" | "opt" | "optUndef">
   testType<OmitByValueExact<RequiredOptionalProps, number>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "opt" | "optUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "opt" | "optUndef">
   testType<OmitByValueExact<RequiredOptionalProps, number | undefined>>();
-  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | "opt" | "optUndef" | undefined>
+  // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | "opt" | "optUndef">
   testType<OmitByValueExact<RequiredOptionalProps, undefined>>();
-  // @dts-jest:pass:snap -> "reqUndef" | "opt" | "optUndef" | undefined
+  // @dts-jest:pass:snap -> "reqUndef" | "opt" | "optUndef"
   testType<keyof OmitByValueExact<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
-    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? never : Key : Key; }[keyof T]>
+    // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]-?: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? never : Key : Key; }[keyof T]>
     testType<OmitByValueExact<T, number>>();
   };
 }

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -148,6 +148,8 @@ type RequiredOptionalProps = {
   testType<PickByValue<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, undefined>
   testType<PickByValue<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap -> "req" | undefined
+  testType<keyof PickByValue<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: T[Key] extends number ? Key : never; }[keyof T]>
@@ -163,6 +165,8 @@ type RequiredOptionalProps = {
   testType<PickByValueExact<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, undefined>
   testType<PickByValueExact<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap -> "req" | undefined
+  testType<keyof PickByValueExact<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? Key : never : never; }[keyof T]>
@@ -195,6 +199,8 @@ type RequiredOptionalProps = {
   testType<OmitByValue<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | "opt" | "optUndef" | undefined>
   testType<OmitByValue<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap -> "reqUndef" | "opt" | "optUndef" | undefined
+  testType<keyof OmitByValue<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: T[Key] extends string | boolean ? never : Key; }[keyof T]>
@@ -210,6 +216,8 @@ type RequiredOptionalProps = {
   testType<OmitByValueExact<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap -> Pick<RequiredOptionalProps, "req" | "reqUndef" | "opt" | "optUndef" | undefined>
   testType<OmitByValueExact<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap -> "reqUndef" | "opt" | "optUndef" | undefined
+  testType<keyof OmitByValueExact<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap -> Pick<T, { [Key in keyof T]: [number] extends [T[Key]] ? [T[Key]] extends [T[Key] & number] ? never : Key : Key; }[keyof T]>

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -148,6 +148,8 @@ type RequiredOptionalProps = {
   testType<PickByValue<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap
   testType<PickByValue<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap
+  testType<keyof PickByValue<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap
@@ -163,6 +165,8 @@ type RequiredOptionalProps = {
   testType<PickByValueExact<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap
   testType<PickByValueExact<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap
+  testType<keyof PickByValueExact<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap
@@ -195,6 +199,8 @@ type RequiredOptionalProps = {
   testType<OmitByValue<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap
   testType<OmitByValue<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap
+  testType<keyof OmitByValue<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap
@@ -210,6 +216,8 @@ type RequiredOptionalProps = {
   testType<OmitByValueExact<RequiredOptionalProps, number | undefined>>();
   // @dts-jest:pass:snap
   testType<OmitByValueExact<RequiredOptionalProps, undefined>>();
+  // @dts-jest:pass:snap
+  testType<keyof OmitByValueExact<RequiredOptionalProps, number>>();
 
   const fn = <T extends Props>(props: T) => {
     // @dts-jest:pass:snap

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -190,7 +190,7 @@ namespace Pick {}
  */
 export type PickByValue<T, ValueType> = Pick<
   T,
-  { [Key in keyof T]: T[Key] extends ValueType ? Key : never }[keyof T]
+  { [Key in keyof T]-?: T[Key] extends ValueType ? Key : never }[keyof T]
 >;
 
 /**
@@ -207,7 +207,7 @@ export type PickByValue<T, ValueType> = Pick<
 export type PickByValueExact<T, ValueType> = Pick<
   T,
   {
-    [Key in keyof T]: [ValueType] extends [T[Key]]
+    [Key in keyof T]-?: [ValueType] extends [T[Key]]
       ? [T[Key]] extends [ValueType]
         ? Key
         : never
@@ -240,7 +240,7 @@ export type Omit<T, K extends keyof any> = Pick<T, SetDifference<keyof T, K>>;
  */
 export type OmitByValue<T, ValueType> = Pick<
   T,
-  { [Key in keyof T]: T[Key] extends ValueType ? never : Key }[keyof T]
+  { [Key in keyof T]-?: T[Key] extends ValueType ? never : Key }[keyof T]
 >;
 
 /**
@@ -257,7 +257,7 @@ export type OmitByValue<T, ValueType> = Pick<
 export type OmitByValueExact<T, ValueType> = Pick<
   T,
   {
-    [Key in keyof T]: [ValueType] extends [T[Key]]
+    [Key in keyof T]-?: [ValueType] extends [T[Key]]
       ? [T[Key]] extends [ValueType]
         ? never
         : Key


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Related issues:
- Resolved #123 

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [x] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
