### PR TITLE
Add $ObjMap support 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
   $ElementType,
   $Keys,
   $NonMaybeType,
+  $ObjMap,
   $PropertyType,
   $ReadOnly,
   $Shape,

--- a/src/utility-types.spec.ts
+++ b/src/utility-types.spec.ts
@@ -9,6 +9,7 @@ import {
   $ElementType,
   $Shape,
   $NonMaybeType,
+  $ObjMap,
   Class,
   mixed,
 } from './utility-types';
@@ -19,8 +20,13 @@ import { _DeepReadonlyObject } from './mapped-types';
 
 type Props = { name: string; age: number; visible: boolean };
 type DefaultProps = { age: number };
+type MappingProps = {
+  foo: () => boolean;
+  bar: () => string;
+  baz: string;
+};
 
-class Foo {}
+class Foo { }
 
 /**
  * Tests
@@ -119,4 +125,10 @@ class Foo {}
 {
   // @dts-jest:pass:snap
   testType<mixed>();
+}
+
+// @dts-jest:group $ObjMap
+{
+  // @dts-jest:pass:snap -> { foo: boolean; bar: string }
+  testType<$ObjMap<MappingProps>>();
 }

--- a/src/utility-types.spec.ts
+++ b/src/utility-types.spec.ts
@@ -26,7 +26,7 @@ type MappingProps = {
   baz: string;
 };
 
-class Foo { }
+class Foo {}
 
 /**
  * Tests

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -158,6 +158,31 @@ export type $NonMaybeType<T> = NonNullable<T>;
 export type Class<T> = new (...args: any[]) => T;
 
 /**
+ * $ObjMap
+ * @desc Mapps the type of each value in the object with the provided function type
+ * @see https://flow.org/en/docs/types/utilities/#toc-objmap
+ * @example
+ *  function mapValues<T extends { [key: string]: (...args: any[]) => any }>(o: T): $ObjMap<T> {
+ *    return (Object.keys(o) as $Keys<T>[]).reduce((acc, k) => ({
+ *       ...acc,
+ *       [k]: o[k]()
+ *    }), {} as $ObjMap<T>);
+ *  }
+ *
+ *  const o = {
+ *    a: () => true,
+ *    b: () => 'foo'
+ *  };
+ *
+ *  const result = mapValues(o).a // boolean
+ */
+export type $ObjMap<T extends Record<string, any>> = {
+  [P in keyof T]: T[P] extends (...args: any[]) => any
+    ? ReturnType<T[P]>
+    : never;
+};
+
+/**
  * mixed
  * @desc An arbitrary type that could be anything
  * @see https://flow.org/en/docs/types/mixed


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
Added support of [$ObjMap](https://flow.org/en/docs/types/utilities/#toc-objmap)

## Related issues:
- Resolved #18 

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [ ] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [x] I have added a short example in API Docs to demonstrate new usage
* [x] I have added type unit tests with `dts-jest`
