### PR TITLE
fix: FunctionKeys and NonFunctionKeys does not filter undefined and null

### DIFF
--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -55,6 +55,8 @@ type MixedProps = {
   setName: (name: string) => void;
   someKeys?: string;
   someFn?: (...args: any) => any;
+  undef: undefined;
+  unNull: null;
 };
 type ReadWriteProps = { readonly a: number; b: string };
 type RequiredOptionalProps = {

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -75,7 +75,9 @@ export type NonUndefined<A> = A extends undefined ? never : A;
  *   type Keys = FunctionKeys<MixedProps>;
  */
 export type FunctionKeys<T extends object> = {
-  [K in keyof T]-?: NonUndefined<T[K]> extends Function ? K : never;
+  [P in keyof T]-?: SetIntersection<NonNullable<T[P]>, Function> extends never
+    ? never
+    : P;
 }[keyof T];
 
 /**
@@ -88,7 +90,9 @@ export type FunctionKeys<T extends object> = {
  *   type Keys = NonFunctionKeys<MixedProps>;
  */
 export type NonFunctionKeys<T extends object> = {
-  [K in keyof T]-?: NonUndefined<T[K]> extends Function ? never : K;
+  [P in keyof T]-?: SetDifference<NonNullable<T[P]>, Function> extends never
+    ? never
+    : P;
 }[keyof T];
 
 /**


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->
When I was using Functionkeys and NonFunctionKeys type, I found that undefined and null were not filtered out
## Related issues:
- Resolved #XXX

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [ ] I have linked all related issues above
* [ ] I have rebased my branch

For bugfixes:
* [x] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
