### PR TITLE
Fix typo in $Call documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,7 +1066,7 @@ import { $Call } from 'utility-types';
 
 // Common use-case
 const add = (amount: number) => ({ type: 'ADD' as 'ADD', payload: amount });
-type AddAction = $Call<typeof returnOfIncrement>; // { type: 'ADD'; payload: number }
+type AddAction = $Call<typeof add>; // { type: 'ADD'; payload: number }
 
 // Examples migrated from Flow docs
 type ExtractPropType<T extends { prop: any }> = (arg: T) => T['prop'];


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->

Fixed a typo in the documentation for how to use `$Call`

## Related issues:
- Resolved #XXX

See https://github.com/piotrwitek/utility-types/issues/149 . I don't know if this patch should close that issue, though.

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [x] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
