### PR TITLE
Link to ReturnType from $Call docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,6 +1059,8 @@ type ValuesType = $ElementType<Obj, string>;
 get the return type of a given expression type<br>
 https://flow.org/en/docs/types/utilities/#toc-call
 
+The built-in [`ReturnType`](https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype) can be used to accomplish the same goal, although it may have some subtle differences.
+
 **Usage:**
 
 ```ts


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->

This adds a link to `ReturnType` from the `$Call` docs so that the user can decide if that will be easier for them. I personally had run into issues with union types where `ReturnType` worked better.

I wasn't sure if it would be better to link to the `ReturnType` implementation in `utility-types` or not, just let me know.

## Related issues:
- Resolved #XXX

See https://github.com/piotrwitek/utility-types/issues/149

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
