### PR TITLE
fix: ReadOnly<T> has a typo in its documentation (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ import { $ReadOnly } from 'utility-types';
 
 type Props = { name: string; age: number; visible: boolean };
 
-// Expect: Readonly<{ name: string; age?: number | undefined; visible: boolean; }>
+// Expect: Readonly<{ name: string; age: number; visible: boolean; }>
 type ReadOnlyProps = $ReadOnly<Props>;
 ```
 

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -31,7 +31,7 @@ export type $Values<T extends object> = T[keyof T];
  * @example
  *   type Props = { name: string; age: number; visible: boolean };
  *
- *   // Expect: Readonly<{ name: string; age?: number | undefined; visible: boolean; }>
+ *   // Expect: Readonly<{ name: string; age: number; visible: boolean; }>
  *   type ReadOnlyProps = $ReadOnly<Props>;
  */
 export type $ReadOnly<T extends object> = DeepReadonly<T>;


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->
Fixed a typo in the usage example of `$ReadOnly<T>`.

## Related issues:
- Resolved #XXX

Refer to #156 .

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [x] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
