### PR TITLE
fix: DeepPartial with generic parameter should allow assigning {}

### DIFF
--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -39,6 +39,10 @@ exports[`DeepNonNullable testType<DeepNonNullable<NestedProps>['first']['second'
 
 exports[`DeepNonNullable testType<DeepNonNullable<NestedProps>['first']['second']['name']>() (type) should match snapshot 1`] = `"string"`;
 
+exports[`DeepPartial testType<DeepPartial<NestedProps>>({}) (type) should match snapshot 1`] = `"DeepPartial<{ first: { second: { name: string; }; }; }>"`;
+
+exports[`DeepPartial testType<DeepPartial<T>>({}) (type) should match snapshot 1`] = `"DeepPartial<T>"`;
+
 exports[`DeepPartial testType<ReturnType<NonNullable<typeof functionProp>>>() (type) should match snapshot 1`] = `"string"`;
 
 exports[`DeepPartial testType<typeof arrayItem.name>() (type) should match snapshot 1`] = `"string | undefined"`;
@@ -49,13 +53,13 @@ exports[`DeepPartial testType<typeof functionProp>() (type) should match snapsho
 
 exports[`DeepPartial testType<typeof name>() (type) should match snapshot 1`] = `"string | undefined"`;
 
-exports[`DeepPartial testType<typeof nestedArrayPartial.first>() (type) should match snapshot 1`] = `"_DeepPartialObject<{ second: { name: string; }[]; }> | undefined"`;
+exports[`DeepPartial testType<typeof nestedArrayPartial.first>() (type) should match snapshot 1`] = `"DeepPartial<{ second: { name: string; }[]; }> | undefined"`;
 
-exports[`DeepPartial testType<typeof nestedFunctionPartial.first>() (type) should match snapshot 1`] = `"_DeepPartialObject<{ second: (value: number) => string; }> | undefined"`;
+exports[`DeepPartial testType<typeof nestedFunctionPartial.first>() (type) should match snapshot 1`] = `"DeepPartial<{ second: (value: number) => string; }> | undefined"`;
 
-exports[`DeepPartial testType<typeof partialNested.first>() (type) should match snapshot 1`] = `"_DeepPartialObject<{ second: { name: string; }; }> | undefined"`;
+exports[`DeepPartial testType<typeof partialNested.first>() (type) should match snapshot 1`] = `"DeepPartial<{ second: { name: string; }; }> | undefined"`;
 
-exports[`DeepPartial testType<typeof second>() (type) should match snapshot 1`] = `"_DeepPartialObject<{ name: string; }> | undefined"`;
+exports[`DeepPartial testType<typeof second>() (type) should match snapshot 1`] = `"DeepPartial<{ name: string; }> | undefined"`;
 
 exports[`DeepReadonly testType<DeepReadonly<DeepReadonly<NestedArrayProps>>>() (type) should match snapshot 1`] = `"_DeepReadonlyObject<{ first: { second: { name: string; }[]; }; }>"`;
 

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -30,7 +30,7 @@ import {
   _DeepReadonlyObject,
   _DeepRequiredArray,
   _DeepRequiredObject,
-  _DeepPartialObject,
+  _DeepPartial,
   _DeepPartialArray,
   RequiredKeys,
   OptionalKeys,
@@ -444,11 +444,11 @@ type RequiredOptionalProps = {
     };
   };
   const partialNested: DeepPartial<NestedProps> = {} as any;
-  // @dts-jest:pass:snap -> _DeepPartialObject<{ second: { name: string; }; }> | undefined
+  // @dts-jest:pass:snap -> DeepPartial<{ second: { name: string; }; }> | undefined
   testType<typeof partialNested.first>();
 
   const second = partialNested.first!.second;
-  // @dts-jest:pass:snap -> _DeepPartialObject<{ name: string; }> | undefined
+  // @dts-jest:pass:snap -> DeepPartial<{ name: string; }> | undefined
   testType<typeof second>();
 
   const name = second!.name;
@@ -462,7 +462,7 @@ type RequiredOptionalProps = {
   };
 
   const nestedArrayPartial: DeepPartial<NestedArrayProps> = {};
-  // @dts-jest:pass:snap -> _DeepPartialObject<{ second: { name: string; }[]; }> | undefined
+  // @dts-jest:pass:snap -> DeepPartial<{ second: { name: string; }[]; }> | undefined
   testType<typeof nestedArrayPartial.first>();
 
   const arrayProp = nestedArrayPartial.first!.second;
@@ -479,7 +479,7 @@ type RequiredOptionalProps = {
     };
   };
   const nestedFunctionPartial: DeepPartial<NestedFunctionProps> = {};
-  // @dts-jest:pass:snap -> _DeepPartialObject<{ second: (value: number) => string; }> | undefined
+  // @dts-jest:pass:snap -> DeepPartial<{ second: (value: number) => string; }> | undefined
   testType<typeof nestedFunctionPartial.first>();
 
   const functionProp = nestedFunctionPartial.first!.second;
@@ -487,6 +487,14 @@ type RequiredOptionalProps = {
   testType<typeof functionProp>();
   // @dts-jest:pass:snap -> string
   testType<ReturnType<NonNullable<typeof functionProp>>>();
+
+  // @dts-jest:pass:snap -> DeepPartial<{ first: { second: { name: string; }; }; }>
+  testType<DeepPartial<NestedProps>>({});
+
+  <T extends object>() => {
+    // @dts-jest:pass:snap -> DeepPartial<T>
+    testType<DeepPartial<T>>({});
+  };
 }
 
 // @dts-jest:group Brand

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -30,7 +30,7 @@ import {
   _DeepReadonlyObject,
   _DeepRequiredArray,
   _DeepRequiredObject,
-  _DeepPartialObject,
+  _DeepPartial,
   _DeepPartialArray,
   RequiredKeys,
   OptionalKeys,
@@ -487,6 +487,14 @@ type RequiredOptionalProps = {
   testType<typeof functionProp>();
   // @dts-jest:pass:snap
   testType<ReturnType<NonNullable<typeof functionProp>>>();
+
+  // @dts-jest:pass:snap
+  testType<DeepPartial<NestedProps>>({});
+
+  <T extends object>() => {
+    // @dts-jest:pass:snap
+    testType<DeepPartial<T>>({});
+  };
 }
 
 // @dts-jest:group Brand

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -501,18 +501,19 @@ export type _DeepNonNullableObject<T> = {
  *   };
  *   type PartialNestedProps = DeepPartial<NestedProps>;
  */
-export type DeepPartial<T> = T extends Function
+export type DeepPartial<T> = { [P in keyof T]?: _DeepPartial<T[P]> };
+
+/** @private */
+export type _DeepPartial<T> = T extends Function
   ? T
   : T extends Array<infer U>
   ? _DeepPartialArray<U>
   : T extends object
-  ? _DeepPartialObject<T>
+  ? DeepPartial<T>
   : T | undefined;
 /** @private */
 // tslint:disable-next-line:class-name
-export interface _DeepPartialArray<T> extends Array<DeepPartial<T>> {}
-/** @private */
-export type _DeepPartialObject<T> = { [P in keyof T]?: DeepPartial<T[P]> };
+export interface _DeepPartialArray<T> extends Array<_DeepPartial<T>> {}
 
 /**
  * Brand


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
DeepPartial supports the assignment of `{}` when the passed type is generic:
```ts
const result: DeepPartial<T> = {}
```

It's not possible to test with `dts-jest`, so I setup an additional `tsconfig.test-d.json` used to run `tsc` on `src/**/*.test-d.ts` files.
It would be even better to integrate types testing library like [tsd](https://github.com/SamVerschueren/tsd), to be able to assert also cases when type error is expected.


## Related issues:
- Resolved #183

## Checklist

* [X] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [X] I have linked all related issues above
* [X] I have rebased my branch

For bugfixes:
* [X] I have added at least one unit test to confirm the bug have been fixed
* [X] I have checked and updated TOC and API Docs when necessary
