### PR TITLE
add 3 hasProperty, hasDefinedProperty, hasValorizedProperty and PossibleKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`isNullish`](#isnullish)
 * [`hasProperty`](#hasproperty)
 * [`hasDefinedProperty`](#hasdefinedproperty)
+* [`hasValorizedProperty`](#hasvalorizedproperty)
 
 ## Union operators
 
@@ -254,6 +255,20 @@ import { hasDefinedProperty } from 'utility-types';
 
 if (hasDefinedProperty(obj, 'prop')) {
   // `prop` in `obj` and `obj.prop` is not `undefined`
+}
+```
+
+### `hasValorizedProperty`
+
+Check if the object has the property and it is not `undefined` and not `null`
+
+**Usage:**
+
+```ts
+import { hasValorizedProperty } from 'utility-types';
+
+if (hasValorizedProperty(obj, 'prop')) {
+  // `prop` in `obj` and `obj.prop` is not `undefined` and not `null`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`isFalsy`](#isfalsy)
 * [`Nullish`](#nullish)
 * [`isNullish`](#isnullish)
+* [`hasProperty`](#hasproperty)
 
 ## Union operators
 
@@ -225,6 +226,20 @@ const consumer = (param: Nullish | string): string => {
     // typeof param === string
     return param.toString();
 };
+```
+
+### `hasProperty` 
+
+Check if the object has the property, similar to [the `in` operator](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing) `'key' in obj` but unexistent properties are not allowed and it allows intellisense
+
+**Usage:**
+
+```ts
+import { hasProperty } from 'utility-types';
+
+if (hasProperty(obj, 'prop')) {
+  // `prop` in `obj`
+}
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`Nullish`](#nullish)
 * [`isNullish`](#isnullish)
 * [`hasProperty`](#hasproperty)
+* [`hasDefinedProperty`](#hasdefinedproperty)
 
 ## Union operators
 
@@ -239,6 +240,20 @@ import { hasProperty } from 'utility-types';
 
 if (hasProperty(obj, 'prop')) {
   // `prop` in `obj`
+}
+```
+
+### `hasDefinedProperty`
+
+Check if the object has the property and it is not `undefined`
+
+**Usage:**
+
+```ts
+import { hasDefinedProperty } from 'utility-types';
+
+if (hasDefinedProperty(obj, 'prop')) {
+  // `prop` in `obj` and `obj.prop` is not `undefined`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`Overwrite<T, U>`](#overwritet-u)
 * [`Assign<T, U>`](#assignt-u)
 * [`ValuesType<T>`](#valuestypet)
+* [`PossibleKeys<T>`](#possiblekeyst)
 
 ## Special operators
 
@@ -418,6 +419,24 @@ type Props = { req: number; reqUndef: number | undefined; opt?: string; optUndef
 
 // Expect: "opt" | "optUndef"
 type Keys = OptionalKeys<Props>;
+```
+
+[⇧ back to top](#table-of-contents)
+
+### `PossibleKeys<T>`
+
+Similar to [`$Keys`](#keyst) or `keyof`, but get keys also from union types
+
+**Usage:**
+
+```ts
+type Props = { name: string; employeeId: string } | { name: string; guestId: string };
+// Expect: "name" | "employeeId" | "guestId"
+type PropsKeys1 = PossibleKeys<Props>;
+// Expect: "name"
+type PropsKeys2 = $Keys<Props>;
+// Expect: "name"
+type PropsKeys3 = keyof Props;
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/src/__snapshots__/aliases-and-guards.spec.ts.snap
+++ b/src/__snapshots__/aliases-and-guards.spec.ts.snap
@@ -6,17 +6,31 @@ exports[`Primitive testType<Primitive>() (type) should match snapshot 1`] = `"Pr
 
 exports[`hasDefinedProperty obj (type) should match snapshot 1`] = `"{ name: string; } & { name: string; }"`;
 
+exports[`hasDefinedProperty obj (type) should match snapshot 2`] = `"{ name: string; } & { name: string; }"`;
+
 exports[`hasDefinedProperty obj1 (type) should match snapshot 1`] = `"{ name?: string | undefined; } & { name: string; }"`;
+
+exports[`hasDefinedProperty obj1 (type) should match snapshot 2`] = `"{ name?: string | undefined; } & { name: string; }"`;
 
 exports[`hasDefinedProperty obj1.name (type) should match snapshot 1`] = `"string"`;
 
+exports[`hasDefinedProperty obj1.name (type) should match snapshot 2`] = `"string"`;
+
 exports[`hasDefinedProperty obj2 (type) should match snapshot 1`] = `"{ name: string | undefined; } & { name: string; }"`;
+
+exports[`hasDefinedProperty obj2 (type) should match snapshot 2`] = `"{ name: string | undefined; } & { name: string; }"`;
 
 exports[`hasDefinedProperty obj2.name (type) should match snapshot 1`] = `"string"`;
 
+exports[`hasDefinedProperty obj2.name (type) should match snapshot 2`] = `"string"`;
+
 exports[`hasDefinedProperty obj3 (type) should match snapshot 1`] = `"{ name: string | null | undefined; } & { name: string | null; }"`;
 
+exports[`hasDefinedProperty obj3 (type) should match snapshot 2`] = `"{ name: string | null | undefined; } & { name: string | null; }"`;
+
 exports[`hasDefinedProperty obj3.name (type) should match snapshot 1`] = `"string | null"`;
+
+exports[`hasDefinedProperty obj3.name (type) should match snapshot 2`] = `"string | null"`;
 
 exports[`hasProperty obj (type) should match snapshot 1`] = `"{ name: string; }"`;
 

--- a/src/__snapshots__/aliases-and-guards.spec.ts.snap
+++ b/src/__snapshots__/aliases-and-guards.spec.ts.snap
@@ -4,6 +4,22 @@ exports[`Falsy testType<Falsy>() (type) should match snapshot 1`] = `"Falsy"`;
 
 exports[`Primitive testType<Primitive>() (type) should match snapshot 1`] = `"Primitive"`;
 
+exports[`hasProperty obj (type) should match snapshot 1`] = `"{ name: string; }"`;
+
+exports[`hasProperty obj1 (type) should match snapshot 1`] = `"{ name?: string | undefined; guestId: string; }"`;
+
+exports[`hasProperty obj1.guestId (type) should match snapshot 1`] = `"string"`;
+
+exports[`hasProperty obj1.name (type) should match snapshot 1`] = `"string | undefined"`;
+
+exports[`hasProperty obj2 (type) should match snapshot 1`] = `"{ name: string | undefined; }"`;
+
+exports[`hasProperty obj2.name (type) should match snapshot 1`] = `"string | undefined"`;
+
+exports[`hasProperty obj3 (type) should match snapshot 1`] = `"{ name?: string | undefined; }"`;
+
+exports[`hasProperty obj3.name (type) should match snapshot 1`] = `"string | undefined"`;
+
 exports[`isFalsy param (type) should match snapshot 1`] = `"false | 0 | null | undefined"`;
 
 exports[`isFalsy param (type) should match snapshot 2`] = `"string"`;

--- a/src/__snapshots__/aliases-and-guards.spec.ts.snap
+++ b/src/__snapshots__/aliases-and-guards.spec.ts.snap
@@ -4,6 +4,20 @@ exports[`Falsy testType<Falsy>() (type) should match snapshot 1`] = `"Falsy"`;
 
 exports[`Primitive testType<Primitive>() (type) should match snapshot 1`] = `"Primitive"`;
 
+exports[`hasDefinedProperty obj (type) should match snapshot 1`] = `"{ name: string; } & { name: string; }"`;
+
+exports[`hasDefinedProperty obj1 (type) should match snapshot 1`] = `"{ name?: string | undefined; } & { name: string; }"`;
+
+exports[`hasDefinedProperty obj1.name (type) should match snapshot 1`] = `"string"`;
+
+exports[`hasDefinedProperty obj2 (type) should match snapshot 1`] = `"{ name: string | undefined; } & { name: string; }"`;
+
+exports[`hasDefinedProperty obj2.name (type) should match snapshot 1`] = `"string"`;
+
+exports[`hasDefinedProperty obj3 (type) should match snapshot 1`] = `"{ name: string | null | undefined; } & { name: string | null; }"`;
+
+exports[`hasDefinedProperty obj3.name (type) should match snapshot 1`] = `"string | null"`;
+
 exports[`hasProperty obj (type) should match snapshot 1`] = `"{ name: string; }"`;
 
 exports[`hasProperty obj1 (type) should match snapshot 1`] = `"{ name?: string | undefined; guestId: string; }"`;

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`$PossibleKeys -> "name" | "employeeId" | "guestId" (type) should match snapshot 1`] = `"\\"name\\" | \\"employeeId\\" | \\"guestId\\""`;
+
 exports[`Assign const result: Assign<{}, Omit<T, 'age'>> = rest (type) should match snapshot 1`] = `"any"`;
 
 exports[`Assign testType<Assign<Props, NewProps>>() (type) should match snapshot 1`] = `"Pick<Pick<Props, \\"name\\" | \\"visible\\"> & Pick<NewProps, \\"age\\"> & Pick<NewProps, \\"other\\">, \\"name\\" | \\"age\\" | \\"visible\\" | \\"other\\">"`;

--- a/src/aliases-and-guards.spec.snap.ts
+++ b/src/aliases-and-guards.spec.snap.ts
@@ -6,6 +6,7 @@ import {
   isFalsy,
   Nullish,
   isNullish,
+  hasProperty,
 } from './aliases-and-guards';
 
 // @dts-jest:group Primitive
@@ -95,4 +96,80 @@ it('returns false for non-nullish', () => {
 
   const testResults = nonNullishTestVals.map(isNullish);
   testResults.forEach(val => expect(val).toBe(false));
+});
+
+// @dts-jest:group hasProperty
+it('narrows to correct type', () => {
+  const obj1 = {
+    name: 'John',
+    guestId: '#123',
+  } as
+    | {
+        name?: string;
+        employeeId: string;
+      }
+    | {
+        name?: string;
+        guestId: string;
+      };
+  if (hasProperty(obj1, 'guestId')) {
+    // @dts-jest:pass:snap -> { name?: string | undefined; guestId: string; }
+    obj1;
+
+    // @dts-jest:pass:snap -> string | undefined
+    obj1.name;
+    expect(obj1.name).toBe('John');
+
+    // @dts-jest:pass:snap -> string
+    obj1.guestId;
+    expect(obj1.guestId).toBe('#123');
+  }
+
+  const obj2 = {
+    name: 'John',
+  } as {
+    name: string | undefined;
+  };
+  if (hasProperty(obj2, 'name')) {
+    // @dts-jest:pass:snap -> { name: string | undefined; }
+    obj2;
+
+    // @dts-jest:pass:snap -> string | undefined
+    obj2.name;
+    expect(obj2.name).toBe('John');
+  }
+
+  const obj3 = {
+    name: 'John',
+  } as {
+    name?: string;
+  };
+  if (hasProperty(obj3, 'name')) {
+    // @dts-jest:pass:snap -> { name?: string | undefined; }
+    obj3;
+
+    // @dts-jest:pass:snap -> string | undefined
+    obj3.name;
+    expect(obj3.name).toBe('John');
+  }
+});
+
+// @dts-jest:group hasProperty
+it('returns false if property is not in object', () => {
+  const obj = {
+    name: 'John',
+  } as {
+    name: string;
+  };
+
+  // @ts-ignore
+  expect(hasProperty(obj, 'guestId')).toBe(false);
+
+  // @ts-ignore
+  if (hasProperty(obj, 'guestId')) {
+    // @dts-jest:pass:snap -> { name: string; }
+    obj;
+
+    throw new Error('should not reach here');
+  }
 });

--- a/src/aliases-and-guards.spec.snap.ts
+++ b/src/aliases-and-guards.spec.snap.ts
@@ -7,6 +7,7 @@ import {
   Nullish,
   isNullish,
   hasProperty,
+  hasDefinedProperty,
 } from './aliases-and-guards';
 
 // @dts-jest:group Primitive
@@ -168,6 +169,71 @@ it('returns false if property is not in object', () => {
   // @ts-ignore
   if (hasProperty(obj, 'guestId')) {
     // @dts-jest:pass:snap -> { name: string; }
+    obj;
+
+    throw new Error('should not reach here');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('narrows to correct type', () => {
+  const obj1 = {
+    name: 'John',
+  } as {
+    name?: string;
+  };
+  if (hasDefinedProperty(obj1, 'name')) {
+    // @dts-jest:pass:snap -> { name?: string | undefined; } & { name: string; }
+    obj1;
+
+    // @dts-jest:pass:snap -> string
+    obj1.name;
+    expect(obj1.name).toBe('John');
+  }
+
+  const obj2 = {
+    name: 'John',
+  } as {
+    name: string | undefined;
+  };
+  if (hasDefinedProperty(obj2, 'name')) {
+    // @dts-jest:pass:snap -> { name: string | undefined; } & { name: string; }
+    obj2;
+
+    // @dts-jest:pass:snap -> string
+    obj2.name;
+    expect(obj2.name).toBe('John');
+  }
+
+  const obj3 = {
+    name: 'John',
+  } as {
+    name: string | null | undefined;
+  };
+  if (hasDefinedProperty(obj3, 'name')) {
+    // @dts-jest:pass:snap -> { name: string | null | undefined; } & { name: string | null; }
+    obj3;
+
+    // @dts-jest:pass:snap -> string | null
+    obj3.name;
+    expect(obj3.name).toBe('John');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('returns false if property is not in object', () => {
+  const obj = {
+    name: 'John',
+  } as {
+    name: string;
+  };
+
+  // @ts-ignore
+  expect(hasDefinedProperty(obj, 'guestId')).toBe(false);
+
+  // @ts-ignore
+  if (hasDefinedProperty(obj, 'guestId')) {
+    // @dts-jest:pass:snap -> { name: string; } & { name: string; }
     obj;
 
     throw new Error('should not reach here');

--- a/src/aliases-and-guards.spec.snap.ts
+++ b/src/aliases-and-guards.spec.snap.ts
@@ -8,6 +8,7 @@ import {
   isNullish,
   hasProperty,
   hasDefinedProperty,
+  hasValorizedProperty,
 } from './aliases-and-guards';
 
 // @dts-jest:group Primitive
@@ -169,6 +170,71 @@ it('returns false if property is not in object', () => {
   // @ts-ignore
   if (hasProperty(obj, 'guestId')) {
     // @dts-jest:pass:snap -> { name: string; }
+    obj;
+
+    throw new Error('should not reach here');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('narrows to correct type', () => {
+  const obj1 = {
+    name: 'John',
+  } as {
+    name?: string;
+  };
+  if (hasDefinedProperty(obj1, 'name')) {
+    // @dts-jest:pass:snap -> { name?: string | undefined; } & { name: string; }
+    obj1;
+
+    // @dts-jest:pass:snap -> string
+    obj1.name;
+    expect(obj1.name).toBe('John');
+  }
+
+  const obj2 = {
+    name: 'John',
+  } as {
+    name: string | undefined;
+  };
+  if (hasDefinedProperty(obj2, 'name')) {
+    // @dts-jest:pass:snap -> { name: string | undefined; } & { name: string; }
+    obj2;
+
+    // @dts-jest:pass:snap -> string
+    obj2.name;
+    expect(obj2.name).toBe('John');
+  }
+
+  const obj3 = {
+    name: 'John',
+  } as {
+    name: string | null | undefined;
+  };
+  if (hasDefinedProperty(obj3, 'name')) {
+    // @dts-jest:pass:snap -> { name: string | null | undefined; } & { name: string | null; }
+    obj3;
+
+    // @dts-jest:pass:snap -> string | null
+    obj3.name;
+    expect(obj3.name).toBe('John');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('returns false if property is not in object', () => {
+  const obj = {
+    name: 'John',
+  } as {
+    name: string;
+  };
+
+  // @ts-ignore
+  expect(hasDefinedProperty(obj, 'guestId')).toBe(false);
+
+  // @ts-ignore
+  if (hasDefinedProperty(obj, 'guestId')) {
+    // @dts-jest:pass:snap -> { name: string; } & { name: string; }
     obj;
 
     throw new Error('should not reach here');

--- a/src/aliases-and-guards.spec.ts
+++ b/src/aliases-and-guards.spec.ts
@@ -7,6 +7,7 @@ import {
   Nullish,
   isNullish,
   hasProperty,
+  hasDefinedProperty,
 } from './aliases-and-guards';
 
 // @dts-jest:group Primitive
@@ -167,6 +168,71 @@ it('returns false if property is not in object', () => {
 
   // @ts-ignore
   if (hasProperty(obj, 'guestId')) {
+    // @dts-jest:pass:snap
+    obj;
+
+    throw new Error('should not reach here');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('narrows to correct type', () => {
+  const obj1 = {
+    name: 'John',
+  } as {
+    name?: string;
+  };
+  if (hasDefinedProperty(obj1, 'name')) {
+    // @dts-jest:pass:snap
+    obj1;
+
+    // @dts-jest:pass:snap
+    obj1.name;
+    expect(obj1.name).toBe('John');
+  }
+
+  const obj2 = {
+    name: 'John',
+  } as {
+    name: string | undefined;
+  };
+  if (hasDefinedProperty(obj2, 'name')) {
+    // @dts-jest:pass:snap
+    obj2;
+
+    // @dts-jest:pass:snap
+    obj2.name;
+    expect(obj2.name).toBe('John');
+  }
+
+  const obj3 = {
+    name: 'John',
+  } as {
+    name: string | null | undefined;
+  };
+  if (hasDefinedProperty(obj3, 'name')) {
+    // @dts-jest:pass:snap
+    obj3;
+
+    // @dts-jest:pass:snap
+    obj3.name;
+    expect(obj3.name).toBe('John');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('returns false if property is not in object', () => {
+  const obj = {
+    name: 'John',
+  } as {
+    name: string;
+  };
+
+  // @ts-ignore
+  expect(hasDefinedProperty(obj, 'guestId')).toBe(false);
+
+  // @ts-ignore
+  if (hasDefinedProperty(obj, 'guestId')) {
     // @dts-jest:pass:snap
     obj;
 

--- a/src/aliases-and-guards.spec.ts
+++ b/src/aliases-and-guards.spec.ts
@@ -8,6 +8,7 @@ import {
   isNullish,
   hasProperty,
   hasDefinedProperty,
+  hasValorizedProperty,
 } from './aliases-and-guards';
 
 // @dts-jest:group Primitive
@@ -168,6 +169,71 @@ it('returns false if property is not in object', () => {
 
   // @ts-ignore
   if (hasProperty(obj, 'guestId')) {
+    // @dts-jest:pass:snap
+    obj;
+
+    throw new Error('should not reach here');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('narrows to correct type', () => {
+  const obj1 = {
+    name: 'John',
+  } as {
+    name?: string;
+  };
+  if (hasDefinedProperty(obj1, 'name')) {
+    // @dts-jest:pass:snap
+    obj1;
+
+    // @dts-jest:pass:snap
+    obj1.name;
+    expect(obj1.name).toBe('John');
+  }
+
+  const obj2 = {
+    name: 'John',
+  } as {
+    name: string | undefined;
+  };
+  if (hasDefinedProperty(obj2, 'name')) {
+    // @dts-jest:pass:snap
+    obj2;
+
+    // @dts-jest:pass:snap
+    obj2.name;
+    expect(obj2.name).toBe('John');
+  }
+
+  const obj3 = {
+    name: 'John',
+  } as {
+    name: string | null | undefined;
+  };
+  if (hasDefinedProperty(obj3, 'name')) {
+    // @dts-jest:pass:snap
+    obj3;
+
+    // @dts-jest:pass:snap
+    obj3.name;
+    expect(obj3.name).toBe('John');
+  }
+});
+
+// @dts-jest:group hasDefinedProperty
+it('returns false if property is not in object', () => {
+  const obj = {
+    name: 'John',
+  } as {
+    name: string;
+  };
+
+  // @ts-ignore
+  expect(hasDefinedProperty(obj, 'guestId')).toBe(false);
+
+  // @ts-ignore
+  if (hasDefinedProperty(obj, 'guestId')) {
     // @dts-jest:pass:snap
     obj;
 

--- a/src/aliases-and-guards.spec.ts
+++ b/src/aliases-and-guards.spec.ts
@@ -6,6 +6,7 @@ import {
   isFalsy,
   Nullish,
   isNullish,
+  hasProperty,
 } from './aliases-and-guards';
 
 // @dts-jest:group Primitive
@@ -95,4 +96,80 @@ it('returns false for non-nullish', () => {
 
   const testResults = nonNullishTestVals.map(isNullish);
   testResults.forEach(val => expect(val).toBe(false));
+});
+
+// @dts-jest:group hasProperty
+it('narrows to correct type', () => {
+  const obj1 = {
+    name: 'John',
+    guestId: '#123',
+  } as
+    | {
+        name?: string;
+        employeeId: string;
+      }
+    | {
+        name?: string;
+        guestId: string;
+      };
+  if (hasProperty(obj1, 'guestId')) {
+    // @dts-jest:pass:snap
+    obj1;
+
+    // @dts-jest:pass:snap
+    obj1.name;
+    expect(obj1.name).toBe('John');
+
+    // @dts-jest:pass:snap
+    obj1.guestId;
+    expect(obj1.guestId).toBe('#123');
+  }
+
+  const obj2 = {
+    name: 'John',
+  } as {
+    name: string | undefined;
+  };
+  if (hasProperty(obj2, 'name')) {
+    // @dts-jest:pass:snap
+    obj2;
+
+    // @dts-jest:pass:snap
+    obj2.name;
+    expect(obj2.name).toBe('John');
+  }
+
+  const obj3 = {
+    name: 'John',
+  } as {
+    name?: string;
+  };
+  if (hasProperty(obj3, 'name')) {
+    // @dts-jest:pass:snap
+    obj3;
+
+    // @dts-jest:pass:snap
+    obj3.name;
+    expect(obj3.name).toBe('John');
+  }
+});
+
+// @dts-jest:group hasProperty
+it('returns false if property is not in object', () => {
+  const obj = {
+    name: 'John',
+  } as {
+    name: string;
+  };
+
+  // @ts-ignore
+  expect(hasProperty(obj, 'guestId')).toBe(false);
+
+  // @ts-ignore
+  if (hasProperty(obj, 'guestId')) {
+    // @dts-jest:pass:snap
+    obj;
+
+    throw new Error('should not reach here');
+  }
 });

--- a/src/aliases-and-guards.ts
+++ b/src/aliases-and-guards.ts
@@ -1,3 +1,5 @@
+import { PossibleKeys } from './mapped-types';
+
 /**
  * Primitive
  * @desc Type representing [`Primitive`](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) types in TypeScript: `string | number | bigint | boolean |  symbol | null | undefined`
@@ -101,3 +103,29 @@ export const isFalsy = (val: unknown): val is Falsy => !val;
  *   };
  */
 export const isNullish = (val: unknown): val is Nullish => val == null;
+
+type ExtractByProperty<O extends object, P extends PossibleKeys<O>> = Extract<
+  O,
+  { [K in P]?: any }
+>;
+/**
+ * Check if the object has the property, similar to {@link https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing | the `in` operator} `'key' in obj` but unexistent properties are not allowed and it allows intellisense
+ *
+ * @template O - object
+ * @template P - a property of O
+ * @param {O} obj: {@type O}
+ * @param {P} property: P
+ * @returns {boolean} `true` if the object has the property, `false` otherwise
+ *
+ * @example
+ *   if (hasProperty(obj, 'prop')) {
+ *     // `prop` in `obj`
+ *   }
+ */
+export const hasProperty = <O extends object, P extends PossibleKeys<O>>(
+  obj: O,
+  property: P
+  // @ts-ignore
+): obj is ExtractByProperty<O, P> => {
+  return property in obj;
+};

--- a/src/aliases-and-guards.ts
+++ b/src/aliases-and-guards.ts
@@ -109,7 +109,9 @@ type ExtractByProperty<O extends object, P extends PossibleKeys<O>> = Extract<
   { [K in P]?: any }
 >;
 /**
- * Check if the object has the property, similar to {@link https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing | the `in` operator} `'key' in obj` but unexistent properties are not allowed and it allows intellisense
+ * Check if the object has the property, similar to
+ * {@link https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing | the `in` operator}
+ * `'key' in obj` but unexistent properties are not allowed and it allows intellisense
  *
  * @template O - object
  * @template P - a property of O
@@ -128,4 +130,31 @@ export const hasProperty = <O extends object, P extends PossibleKeys<O>>(
   // @ts-ignore
 ): obj is ExtractByProperty<O, P> => {
   return property in obj;
+};
+
+type ExtractByPropertyAndAssertNotUndefined<
+  O extends object,
+  P extends PossibleKeys<O>
+> = ExtractByProperty<O, P> &
+  { [K in P]: Exclude<ExtractByProperty<O, K>[K], undefined> };
+/**
+ * Check if the object has the property and it is not `undefined`
+ *
+ * @template O - object
+ * @template P - a property of O
+ * @param {O} obj: {@type O}
+ * @param {P} property: P
+ * @returns {boolean} `true` if the object has the property and is not `undefined`, `false` otherwise
+ *
+ * @example
+ *   if (hasDefinedProperty(obj, 'prop')) {
+ *     // `prop` in `obj` and `obj.prop` is not `undefined`
+ *   }
+ */
+export const hasDefinedProperty = <O extends object, P extends PossibleKeys<O>>(
+  obj: O,
+  property: P
+  // @ts-ignore
+): obj is ExtractByPropertyAndAssertNotUndefined<O, P> => {
+  return property in obj && obj[property] !== undefined;
 };

--- a/src/aliases-and-guards.ts
+++ b/src/aliases-and-guards.ts
@@ -158,3 +158,33 @@ export const hasDefinedProperty = <O extends object, P extends PossibleKeys<O>>(
 ): obj is ExtractByPropertyAndAssertNotUndefined<O, P> => {
   return property in obj && obj[property] !== undefined;
 };
+
+type ExtractByPropertyAndAssertNotNullish<
+  O extends object,
+  P extends PossibleKeys<O>
+> = ExtractByProperty<O, P> &
+  { [K in P]: Exclude<ExtractByProperty<O, K>[K], null | undefined> };
+/**
+ * Check if the object has the property and it is not `null` or `undefined`
+ *
+ * @template O - object
+ * @template P - a property of O
+ * @param {O} obj: {@type O}
+ * @param {P} property: P
+ * @returns {boolean} `true` if the object has the property and is not `null` or `undefined`, `false` otherwise
+ *
+ * @example
+ *   if (hasValorizedProperty(obj, 'prop')) {
+ *     // `prop` in `obj` and `obj.prop` is not `null` or `undefined`
+ *   }
+ */
+export function hasValorizedProperty<
+  O extends object,
+  P extends PossibleKeys<O>
+>(
+  obj: O,
+  property: P
+  // @ts-ignore
+): obj is ExtractByPropertyAndAssertNotNullish<O, P> {
+  return property in obj && obj[property] != null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export {
   isNullish,
   Primitive,
   isPrimitive,
+  hasProperty
 } from './aliases-and-guards';
 
 // deprecated

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export {
   ValuesType,
   Writable,
   WritableKeys,
+  PossibleKeys
 } from './mapped-types';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,8 @@ export {
   isNullish,
   Primitive,
   isPrimitive,
-  hasProperty
+  hasProperty,
+  hasDefinedProperty,
 } from './aliases-and-guards';
 
 // deprecated

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export {
   ValuesType,
   Writable,
   WritableKeys,
-  PossibleKeys
+  PossibleKeys,
 } from './mapped-types';
 
 export {
@@ -66,6 +66,7 @@ export {
   isPrimitive,
   hasProperty,
   hasDefinedProperty,
+  hasValorizedProperty,
 } from './aliases-and-guards';
 
 // deprecated

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -41,6 +41,7 @@ import {
   AugmentedRequired,
   UnionToIntersection,
   Mutable,
+  PossibleKeys,
 } from './mapped-types';
 
 /**
@@ -138,6 +139,23 @@ type RequiredOptionalProps = {
 {
   // @dts-jest:pass:snap -> "opt" | "optUndef"
   testType<OptionalKeys<RequiredOptionalProps>>();
+}
+
+// @dts-jest:group $PossibleKeys
+{
+  // @dts-jest:pass:snap -> "name" | "employeeId" | "guestId" -> "name" | "employeeId" | "guestId"
+  testType<
+    PossibleKeys<
+      | {
+          name: string;
+          employeeId: string;
+        }
+      | {
+          name: string;
+          guestId: string;
+        }
+    >
+  >();
 }
 
 // @dts-jest:group PickByValue

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -41,6 +41,7 @@ import {
   AugmentedRequired,
   UnionToIntersection,
   Mutable,
+  PossibleKeys,
 } from './mapped-types';
 
 /**
@@ -138,6 +139,23 @@ type RequiredOptionalProps = {
 {
   // @dts-jest:pass:snap
   testType<OptionalKeys<RequiredOptionalProps>>();
+}
+
+// @dts-jest:group $PossibleKeys
+{
+  // @dts-jest:pass:snap -> "name" | "employeeId" | "guestId"
+  testType<
+    PossibleKeys<
+      | {
+          name: string;
+          employeeId: string;
+        }
+      | {
+          name: string;
+          guestId: string;
+        }
+    >
+  >();
 }
 
 // @dts-jest:group PickByValue

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -166,6 +166,23 @@ export type OptionalKeys<T> = {
 }[keyof T];
 
 /**
+ * PossibleKeys
+ * @desc Similar to {@link $Keys} or `keyof`, but get keys also from union types
+ * @example
+ *   type Props = { name: string; employeeId: string } | { name: string; guestId: string };
+ *
+ *   // Expect: "name" | "employeeId" | "guestId"
+ *   type PropsKeys1 = PossibleKeys<Props>;
+ *
+ *   // Expect: "name"
+ *   type PropsKeys2 = $Keys<Props>;
+ *
+ *   // Expect: "name"
+ *   type PropsKeys3 = keyof Props;
+ */
+export type PossibleKeys<T> = T extends T ? keyof T : never;
+
+/**
  * Pick (complements Omit)
  * @desc From `T` pick a set of properties by key `K`
  * @example


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->

Add 3 new objects related functions and 1 new utility type for union types:

### `hasProperty` 

Check if the object has the property, similar to [the `in` operator](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing) `'key' in obj` but unexistent properties are not allowed and it allows intellisense

**Usage:**

```ts
import { hasProperty } from 'utility-types';

if (hasProperty(obj, 'prop')) {
  // `prop` in `obj`
}
```

### `hasDefinedProperty`

Check if the object has the property and it is not `undefined`

**Usage:**

```ts
import { hasDefinedProperty } from 'utility-types';

if (hasDefinedProperty(obj, 'prop')) {
  // `prop` in `obj` and `obj.prop` is not `undefined`
}
```

### `hasValorizedProperty`

Check if the object has the property and it is not `undefined` and not `null`

**Usage:**

```ts
import { hasValorizedProperty } from 'utility-types';

if (hasValorizedProperty(obj, 'prop')) {
  // `prop` in `obj` and `obj.prop` is not `undefined` and not `null`
}
```

### `PossibleKeys<T>`

Similar to [`$Keys`](#keyst) or `keyof`, but get keys also from union types

**Usage:**

```ts
type Props = { name: string; employeeId: string } | { name: string; guestId: string };
// Expect: "name" | "employeeId" | "guestId"
type PropsKeys1 = PossibleKeys<Props>;
// Expect: "name"
type PropsKeys2 = $Keys<Props>;
// Expect: "name"
type PropsKeys3 = keyof Props;
```

## Related issues:
- Resolve #189

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [x] I have added entry in TOC and API Docs
* [x] I have added a short example in API Docs to demonstrate new usage
* [x] I have added type unit tests with `dts-jest`
