### PR TITLE
Add NonEmptyArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`Unionize<T>`](#unionizet)
 * [`Brand<T, U>`](#brandt-u)
 * [`UnionToIntersection<U>`](#uniontointersectionu)
+* [`NonEmptyArray<T>`](#)
 
 ## Flow's Utility Types
 
@@ -940,6 +941,20 @@ UnionToIntersection<{ name: string } | { age: number } | { visible: boolean }>
 
 [⇧ back to top](#table-of-contents)
 
+### `NonEmptyArray<T>`
+
+Ensures that the array has at least one element of type `T`.
+
+**Usage:**
+
+```ts
+import { NonEmptyArray } from 'utility-types'
+
+type StringArray = NonEmptyArray<string>;
+
+const valid_array: StringArray = ["foo", "bar"] // Is accepted, as elements exist in the array.
+const invalid_array: StringArray = [] // Source has 0 element(s) but target requires at least 1.
+```
 ---
 
 ## Flow's Utility Types

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`Unionize<T>`](#unionizet)
 * [`Brand<T, U>`](#brandt-u)
 * [`UnionToIntersection<U>`](#uniontointersectionu)
-* [`NonEmptyArray<T>`](#)
+* [`NonEmptyArray<T>`](#nonemptyarrayt)
 
 ## Flow's Utility Types
 

--- a/src/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__snapshots__/mapped-types.spec.ts.snap
@@ -129,6 +129,12 @@ exports[`Mutable testType<Mutable<Readonly<Props>>['visible']>(true) (type) shou
 
 exports[`MutableKeys testType<MutableKeys<ReadWriteProps>>() (type) should match snapshot 1`] = `"\\"b\\""`;
 
+exports[`NonEmptyArray testType<ValidNumberArray>([1, 2, 3]) (type) should match snapshot 1`] = `"NonEmptyArray<number>"`;
+
+exports[`NonEmptyArray testType<ValidObjectArray>([{ foo: 'bar' }, { baz: 'qux' }]) (type) should match snapshot 1`] = `"NonEmptyArray<Record<string, string>>"`;
+
+exports[`NonEmptyArray testType<ValidStringArray>(['foo', 'bar']) (type) should match snapshot 1`] = `"NonEmptyArray<string>"`;
+
 exports[`NonFunctionKeys testType<NonFunctionKeys<MixedProps>>() (type) should match snapshot 1`] = `"\\"name\\" | \\"someKeys\\""`;
 
 exports[`NonUndefined testType<NonUndefined<string | null | undefined>>() (type) should match snapshot 1`] = `"string | null"`;

--- a/src/mapped-types.spec.snap.ts
+++ b/src/mapped-types.spec.snap.ts
@@ -42,6 +42,7 @@ import {
   AugmentedRequired,
   UnionToIntersection,
   Mutable,
+  NonEmptyArray,
 } from './mapped-types';
 
 /**
@@ -604,4 +605,22 @@ type RequiredOptionalProps = {
 
   // @dts-jest:pass:snap -> boolean
   testType<Mutable<Readonly<Props>>['visible']>(true);
+}
+
+// @dts-jest:group NonEmptyArray
+{
+  type ValidStringArray = NonEmptyArray<string>;
+
+  // @dts-jest:pass:snap -> NonEmptyArray<string>
+  testType<ValidStringArray>(['foo', 'bar']);
+
+  type ValidNumberArray = NonEmptyArray<number>;
+
+  // @dts-jest:pass:snap -> NonEmptyArray<number>
+  testType<ValidNumberArray>([1, 2, 3]);
+
+  type ValidObjectArray = NonEmptyArray<Record<string, string>>;
+
+  // @dts-jest:pass:snap -> NonEmptyArray<Record<string, string>>
+  testType<ValidObjectArray>([{ foo: 'bar' }, { baz: 'qux' }]);
 }

--- a/src/mapped-types.spec.ts
+++ b/src/mapped-types.spec.ts
@@ -42,6 +42,7 @@ import {
   AugmentedRequired,
   UnionToIntersection,
   Mutable,
+  NonEmptyArray,
 } from './mapped-types';
 
 /**
@@ -604,4 +605,22 @@ type RequiredOptionalProps = {
 
   // @dts-jest:pass:snap
   testType<Mutable<Readonly<Props>>['visible']>(true);
+}
+
+// @dts-jest:group NonEmptyArray
+{
+  type ValidStringArray = NonEmptyArray<string>;
+
+  // @dts-jest:pass:snap
+  testType<ValidStringArray>(['foo', 'bar']);
+
+  type ValidNumberArray = NonEmptyArray<number>;
+
+  // @dts-jest:pass:snap
+  testType<ValidNumberArray>([1, 2, 3]);
+
+  type ValidObjectArray = NonEmptyArray<Record<string, string>>;
+
+  // @dts-jest:pass:snap
+  testType<ValidObjectArray>([{ foo: 'bar' }, { baz: 'qux' }]);
 }

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -659,3 +659,16 @@ export type UnionToIntersection<U> = (U extends any
  */
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 export type Writable<T> = Mutable<T>;
+
+/**
+ * NonEmptyArray
+ * @desc Ensures that the array has at least one element of type `T`.
+ * Credit: davidtjones02 + Leandro-Albano
+ * @see https://github.com/piotrwitek/utility-types/issues/181
+ * @example
+ *    type StringArray = NonEmptyArray<string>;
+ *
+ *    const valid_array: StringArray = ["foo", "bar"]; // Is accepted, as elements exist in the array.
+ *    const invalid_array: StringArray = [] // Source has 0 element(s) but target requires at least 1.
+ */
+export type NonEmptyArray<T> = [T, ...T[]];


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
Added NonEmptyArray to type utilities. Existed as an outstanding issue for a while that from what I can tell hasn't had a PR yet. Useful for ensuring your arrays are not empty if the expectation is to provide at least one item of a varying type. 

Please let me know if any additional work is needed, hoping I've added where necessary!

Cheers.

## Related issues:
- Resolved #[181](https://github.com/piotrwitek/utility-types/issues/181)

## Checklist

* [X] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [X] I have linked all related issues above
* [X] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [X] I have added entry in TOC and API Docs
* [X] I have added a short example in API Docs to demonstrate new usage
* [X] I have added type unit tests with `dts-jest`
