### PR TITLE
updated age type to number in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ import { Assign } from 'utility-types';
 type Props = { name: string; age: number; visible: boolean };
 type NewProps = { age: string; other: string };
 
-// Expect: { name: string; age: string; visible: boolean; other: string; }
+// Expect: { name: string; age: number; visible: boolean; other: string; }
 type ExtendedProps = Assign<Props, NewProps>;
 ```
 


### PR DESCRIPTION
<!-- Thank you for your contribution! 👍 -->
<!-- Please make sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description

Fix: Corrected the type of `age` from `string` to `number` as per [issue #182](https://github.com/piotrwitek/utility-types/issues/182).  
This was a one-word change to fix an incorrect type definition.

## Related issues:
- Resolved #182

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/utility-types/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug has been fixed  
  > **Reason:** The fix is a trivial one-word type correction (`string` → `number`), easy to visually verify.
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
