### PR TITLE
Add generated API documentation site POC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# utility-types API
+
+This documentation is generated from the exported TypeScript declarations and JSDoc comments in `src/`.
+
+Run `npm run docs:api` after source changes to refresh the pages and sidebar.
+
+- [Mapped Types](api/mapped-types.md) - 36 exports from `src/mapped-types.ts`
+- [Flow's Utility Types](api/utility-types.md) - 10 exports from `src/utility-types.ts`
+- [Aliases & Type Guards](api/aliases-and-guards.md) - 7 exports from `src/aliases-and-guards.ts`
+- [Deprecated API](api/functional-helpers.md) - 1 export from `src/functional-helpers.ts`

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,5 @@
+- [Overview](README.md)
+- [Mapped Types](api/mapped-types.md)
+- [Flow's Utility Types](api/utility-types.md)
+- [Aliases & Type Guards](api/aliases-and-guards.md)
+- [Deprecated API](api/functional-helpers.md)

--- a/docs/api/aliases-and-guards.md
+++ b/docs/api/aliases-and-guards.md
@@ -1,0 +1,159 @@
+# Aliases & Type Guards
+
+Generated from `src/aliases-and-guards.ts`.
+
+- [`Falsey`](#falsey)
+- [`Falsy`](#falsy)
+- [`isFalsy`](#isfalsy)
+- [`isNullish`](#isnullish)
+- [`isPrimitive`](#isprimitive)
+- [`Nullish`](#nullish)
+- [`Primitive`](#primitive)
+
+## `Falsey`
+
+Type representing falsy values in TypeScript: `false | "" | 0 | null | undefined`
+
+Source export: `Falsy`
+
+```ts
+export type Falsy = false | '' | 0 | null | undefined;
+```
+
+### Examples
+
+```ts
+type Various = 'a' | 'b' | undefined | false;
+
+  // Expect: "a" | "b"
+  Exclude<Various, Falsy>;
+```
+
+## `Falsy`
+
+Type representing falsy values in TypeScript: `false | "" | 0 | null | undefined`
+
+```ts
+export type Falsy = false | '' | 0 | null | undefined;
+```
+
+### Examples
+
+```ts
+type Various = 'a' | 'b' | undefined | false;
+
+  // Expect: "a" | "b"
+  Exclude<Various, Falsy>;
+```
+
+## `isFalsy`
+
+Tests for Falsy by simply applying negation `!` to the tested `val`.
+
+The value is mostly in added type-information and explicity,
+but in case of this simple type much the same can often be archived by just using negation `!`:
+
+```ts
+export const isFalsy: (val: unknown) => val is Falsy;
+```
+
+### Examples
+
+```ts
+const consumer = (value: boolean | Falsy) => {
+    if (!value) {
+        return ;
+    }
+    type newType = typeof value; // === true
+    // do stuff
+  };
+```
+
+## `isNullish`
+
+Tests for Nullish by simply comparing `val` for equality with `null`.
+
+```ts
+export const isNullish: (val: unknown) => val is Nullish;
+```
+
+### Examples
+
+```ts
+const consumer = (param: Nullish | string): string => {
+    if (isNullish(param)) {
+      // typeof param === Nullish
+      return String(param) + ' was Nullish';
+    }
+    // typeof param === string
+    return param.toString();
+  };
+```
+
+## `isPrimitive`
+
+Tests for one of the [`Primitive`](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) types using the JavaScript [`typeof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof) operator
+
+Clarification: TypeScript overloads this operator to produce TypeScript types if used in context of types.
+
+```ts
+export const isPrimitive: (val: unknown) => val is Primitive;
+```
+
+### Notes
+
+- `@param` val The value to be tested
+- `@returns` If `val` is primitive. If used in the flow of the program typescript will infer type-information from this.
+
+### Examples
+
+```ts
+const consumer = (value: Primitive | Primitive[]) => {
+      if (isPrimitive(value)) {
+          return console.log('Primitive value: ', value);
+      }
+      // type of value now inferred as Primitive[]
+      value.map((primitive) => consumer(primitive));
+  };
+```
+
+## `Nullish`
+
+Type representing [nullish values][https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing] in TypeScript: `null | undefined`
+
+```ts
+export type Nullish = null | undefined;
+```
+
+### Examples
+
+```ts
+type Various = 'a' | 'b' | undefined;
+
+  // Expect: "a" | "b"
+  Exclude<Various, Nullish>;
+```
+
+## `Primitive`
+
+Type representing [`Primitive`](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) types in TypeScript: `string | number | bigint | boolean |  symbol | null | undefined`
+
+```ts
+export type Primitive =
+  | string
+  | number
+  | bigint
+  | boolean
+  | symbol
+  | null
+  | undefined;
+```
+
+### Examples
+
+```ts
+type Various = number | string | object;
+
+   // Expect: object
+  type Cleaned = Exclude<Various, Primitive>
+```

--- a/docs/api/aliases-and-guards.md
+++ b/docs/api/aliases-and-guards.md
@@ -119,7 +119,7 @@ const consumer = (value: Primitive | Primitive[]) => {
 
 ## `Nullish`
 
-Type representing [nullish values][https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing] in TypeScript: `null | undefined`
+Type representing [nullish values](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing) in TypeScript: `null | undefined`
 
 ```ts
 export type Nullish = null | undefined;

--- a/docs/api/functional-helpers.md
+++ b/docs/api/functional-helpers.md
@@ -1,0 +1,24 @@
+# Deprecated API
+
+Generated from `src/functional-helpers.ts`.
+
+- [`getReturnOfExpression`](#getreturnofexpression)
+
+## `getReturnOfExpression`
+
+```ts
+export function getReturnOfExpression<RT>(
+  expression: (...params: any[]) => RT
+): RT {
+  return (undefined as any) as RT;
+}
+```
+
+### Notes
+
+- `@function` getReturnOfExpression
+- `@deprecated` from TS v2.8 use built-in ReturnType<T> or $Call API
+- `@description` infer the return type from a given "expression" (at runtime it's equivalent of "noop")
+- `@template` RT - ReturnType
+- `@param` expression : (...params: any[]) => RT
+- `@returns` undefined as RT

--- a/docs/api/functional-helpers.md
+++ b/docs/api/functional-helpers.md
@@ -9,9 +9,7 @@ Generated from `src/functional-helpers.ts`.
 ```ts
 export function getReturnOfExpression<RT>(
   expression: (...params: any[]) => RT
-): RT {
-  return (undefined as any) as RT;
-}
+): RT;
 ```
 
 ### Notes

--- a/docs/api/mapped-types.md
+++ b/docs/api/mapped-types.md
@@ -358,7 +358,7 @@ export type NonUndefined<A> = A extends undefined ? never : A;
 
 ```ts
 // Expect: "string | null"
-  SymmetricDifference<string | null | undefined>;
+  NonUndefined<string | null | undefined>;
 ```
 
 ## `Omit`

--- a/docs/api/mapped-types.md
+++ b/docs/api/mapped-types.md
@@ -1,0 +1,855 @@
+# Mapped Types
+
+Generated from `src/mapped-types.ts`.
+
+- [`Assign`](#assign)
+- [`Brand`](#brand)
+- [`DeepNonNullable`](#deepnonnullable)
+- [`DeepPartial`](#deeppartial)
+- [`DeepReadonly`](#deepreadonly)
+- [`DeepRequired`](#deeprequired)
+- [`Diff`](#diff)
+- [`FunctionKeys`](#functionkeys)
+- [`Intersection`](#intersection)
+- [`Mutable`](#mutable)
+- [`MutableKeys`](#mutablekeys)
+- [`NonFunctionKeys`](#nonfunctionkeys)
+- [`NonUndefined`](#nonundefined)
+- [`Omit`](#omit)
+- [`OmitByValue`](#omitbyvalue)
+- [`OmitByValueExact`](#omitbyvalueexact)
+- [`Optional`](#optional)
+- [`OptionalKeys`](#optionalkeys)
+- [`Overwrite`](#overwrite)
+- [`PickByValue`](#pickbyvalue)
+- [`PickByValueExact`](#pickbyvalueexact)
+- [`PromiseType`](#promisetype)
+- [`ReadonlyKeys`](#readonlykeys)
+- [`Required`](#required)
+- [`RequiredKeys`](#requiredkeys)
+- [`SetComplement`](#setcomplement)
+- [`SetDifference`](#setdifference)
+- [`SetIntersection`](#setintersection)
+- [`Subtract`](#subtract)
+- [`SymmetricDifference`](#symmetricdifference)
+- [`Unionize`](#unionize)
+- [`UnionKeys`](#unionkeys)
+- [`UnionToIntersection`](#uniontointersection)
+- [`ValuesType`](#valuestype)
+- [`Writable`](#writable)
+- [`WritableKeys`](#writablekeys)
+
+## `Assign`
+
+From `U` assign properties to `T` (just like object assign)
+
+```ts
+export type Assign<
+  T extends object,
+  U extends object,
+  I = Diff<T, U> & Intersection<U, T> & Diff<U, T>
+> = Pick<I, keyof I>;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+  type NewProps = { age: string; other: string };
+
+  // Expect: { name: string; age: number; visible: boolean; other: string; }
+  type ExtendedProps = Assign<Props, NewProps>;
+```
+
+## `Brand`
+
+Define nominal type of U based on type of T. Similar to Opaque types in Flow.
+
+```ts
+export type Brand<T, U> = T & { __brand: U };
+```
+
+### Examples
+
+```ts
+type USD = Brand<number, "USD">
+  type EUR = Brand<number, "EUR">
+
+  const tax = 5 as USD;
+  const usd = 10 as USD;
+  const eur = 10 as EUR;
+
+  function gross(net: USD): USD {
+    return (net + tax) as USD;
+  }
+
+  // Expect: No compile error
+  gross(usd);
+  // Expect: Compile error (Type '"EUR"' is not assignable to type '"USD"'.)
+  gross(eur);
+```
+
+## `DeepNonNullable`
+
+NonNullable that works for deeply nested structure
+
+```ts
+export type DeepNonNullable<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends any[]
+  ? _DeepNonNullableArray<T[number]>
+  : T extends object
+  ? _DeepNonNullableObject<T>
+  : T;
+```
+
+### Examples
+
+```ts
+// Expect: {
+  //   first: {
+  //     second: {
+  //       name: string;
+  //     };
+  //   };
+  // }
+  type NestedProps = {
+    first?: null | {
+      second?: null | {
+        name?: string | null |
+        undefined;
+      };
+    };
+  };
+  type RequiredNestedProps = DeepNonNullable<NestedProps>;
+```
+
+## `DeepPartial`
+
+Partial that works for deeply nested structure
+
+```ts
+export type DeepPartial<T> = { [P in keyof T]?: _DeepPartial<T[P]> };
+```
+
+### Examples
+
+```ts
+// Expect: {
+  //   first?: {
+  //     second?: {
+  //       name?: string;
+  //     };
+  //   };
+  // }
+  type NestedProps = {
+    first: {
+      second: {
+        name: string;
+      };
+    };
+  };
+  type PartialNestedProps = DeepPartial<NestedProps>;
+```
+
+## `DeepReadonly`
+
+Readonly that works for deeply nested structure
+
+```ts
+export type DeepReadonly<T> = T extends ((...args: any[]) => any) | Primitive
+  ? T
+  : T extends _DeepReadonlyArray<infer U>
+  ? _DeepReadonlyArray<U>
+  : T extends _DeepReadonlyObject<infer V>
+  ? _DeepReadonlyObject<V>
+  : T;
+```
+
+### Examples
+
+```ts
+// Expect: {
+  //   readonly first: {
+  //     readonly second: {
+  //       readonly name: string;
+  //     };
+  //   };
+  // }
+  type NestedProps = {
+    first: {
+      second: {
+        name: string;
+      };
+    };
+  };
+  type ReadonlyNestedProps = DeepReadonly<NestedProps>;
+```
+
+## `DeepRequired`
+
+Required that works for deeply nested structure
+
+```ts
+export type DeepRequired<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends any[]
+  ? _DeepRequiredArray<T[number]>
+  : T extends object
+  ? _DeepRequiredObject<T>
+  : T;
+```
+
+### Examples
+
+```ts
+// Expect: {
+  //   first: {
+  //     second: {
+  //       name: string;
+  //     };
+  //   };
+  // }
+  type NestedProps = {
+    first?: {
+      second?: {
+        name?: string;
+      };
+    };
+  };
+  type RequiredNestedProps = DeepRequired<NestedProps>;
+```
+
+## `Diff`
+
+From `T` remove properties that exist in `U`
+
+```ts
+export type Diff<T extends object, U extends object> = Pick<
+  T,
+  SetDifference<keyof T, keyof U>
+>;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+  type DefaultProps = { age: number };
+
+  // Expect: { name: string; visible: boolean; }
+  type DiffProps = Diff<Props, DefaultProps>;
+```
+
+## `FunctionKeys`
+
+Get union type of keys that are functions in object type `T`
+
+```ts
+export type FunctionKeys<T extends object> = {
+  [K in keyof T]-?: NonUndefined<T[K]> extends Function ? K : never;
+}[keyof T];
+```
+
+### Examples
+
+```ts
+type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
+
+  // Expect: "setName | someFn"
+  type Keys = FunctionKeys<MixedProps>;
+```
+
+## `Intersection`
+
+From `T` pick properties that exist in `U`
+
+```ts
+export type Intersection<T extends object, U extends object> = Pick<
+  T,
+  Extract<keyof T, keyof U> & Extract<keyof U, keyof T>
+>;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+  type DefaultProps = { age: number };
+
+  // Expect: { age: number; }
+  type DuplicateProps = Intersection<Props, DefaultProps>;
+```
+
+## `Mutable`
+
+From `T` make all properties become mutable
+
+```ts
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+```
+
+### Examples
+
+```ts
+type Props = {
+     readonly name: string;
+     readonly age: number;
+     readonly visible: boolean;
+   };
+
+   // Expect: { name: string; age: number; visible: boolean; }
+   Mutable<Props>;
+```
+
+## `MutableKeys`
+
+Get union type of keys that are mutable in object type `T`
+Credit: Matt McCutchen
+https://stackoverflow.com/questions/52443276/how-to-exclude-getter-only-properties-from-type-in-typescript
+
+```ts
+export type MutableKeys<T extends object> = {
+  [P in keyof T]-?: IfEquals<
+    { [Q in P]: T[P] },
+    { -readonly [Q in P]: T[P] },
+    P
+  >;
+}[keyof T];
+```
+
+### Examples
+
+```ts
+type Props = { readonly foo: string; bar: number };
+
+  // Expect: "bar"
+  type Keys = MutableKeys<Props>;
+```
+
+## `NonFunctionKeys`
+
+Get union type of keys that are non-functions in object type `T`
+
+```ts
+export type NonFunctionKeys<T extends object> = {
+  [K in keyof T]-?: NonUndefined<T[K]> extends Function ? never : K;
+}[keyof T];
+```
+
+### Examples
+
+```ts
+type MixedProps = {name: string; setName: (name: string) => void; someKeys?: string; someFn?: (...args: any) => any;};
+
+  // Expect: "name | someKey"
+  type Keys = NonFunctionKeys<MixedProps>;
+```
+
+## `NonUndefined`
+
+Exclude undefined from set `A`
+
+```ts
+export type NonUndefined<A> = A extends undefined ? never : A;
+```
+
+### Examples
+
+```ts
+// Expect: "string | null"
+  SymmetricDifference<string | null | undefined>;
+```
+
+## `Omit`
+
+From `T` remove a set of properties by key `K`
+
+```ts
+export type Omit<T, K extends keyof any> = Pick<T, SetDifference<keyof T, K>>;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+  // Expect: { name: string; visible: boolean; }
+  type Props = Omit<Props, 'age'>;
+```
+
+## `OmitByValue`
+
+From `T` remove a set of properties by value matching `ValueType`.
+Credit: [Piotr Lewandowski](https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c)
+
+```ts
+export type OmitByValue<T, ValueType> = Pick<
+  T,
+  { [Key in keyof T]-?: T[Key] extends ValueType ? never : Key }[keyof T]
+>;
+```
+
+### Examples
+
+```ts
+type Props = { req: number; reqUndef: number | undefined; opt?: string; };
+
+  // Expect: { reqUndef: number | undefined; opt?: string; }
+  type Props = OmitByValue<Props, number>;
+  // Expect: { opt?: string; }
+  type Props = OmitByValue<Props, number | undefined>;
+```
+
+## `OmitByValueExact`
+
+From `T` remove a set of properties by value matching exact `ValueType`.
+
+```ts
+export type OmitByValueExact<T, ValueType> = Pick<
+  T,
+  {
+    [Key in keyof T]-?: [ValueType] extends [T[Key]]
+      ? [T[Key]] extends [ValueType]
+        ? never
+        : Key
+      : Key;
+  }[keyof T]
+>;
+```
+
+### Examples
+
+```ts
+type Props = { req: number; reqUndef: number | undefined; opt?: string; };
+
+  // Expect: { reqUndef: number | undefined; opt?: string; }
+  type Props = OmitByValueExact<Props, number>;
+  // Expect: { req: number; opt?: string }
+  type Props = OmitByValueExact<Props, number | undefined>;
+```
+
+## `Optional`
+
+From `T` make a set of properties by key `K` become optional
+
+```ts
+export type Optional<T extends object, K extends keyof T = keyof T> = Omit<
+  T,
+  K
+> &
+  Partial<Pick<T, K>>;
+```
+
+### Examples
+
+```ts
+type Props = {
+     name: string;
+     age: number;
+     visible: boolean;
+   };
+
+   // Expect: { name?: string; age?: number; visible?: boolean; }
+   type Props = Optional<Props>;
+
+   // Expect: { name: string; age?: number; visible?: boolean; }
+   type Props = Optional<Props, 'age' | 'visible'>;
+```
+
+## `OptionalKeys`
+
+Get union type of keys that are optional in object type `T`
+
+```ts
+export type OptionalKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never;
+}[keyof T];
+```
+
+### Notes
+
+- `@see` https://stackoverflow.com/questions/52984808/is-there-a-way-to-get-all-required-properties-of-a-typescript-object
+
+### Examples
+
+```ts
+type Props = { req: number; reqUndef: number | undefined; opt?: string; optUndef?: number | undefined; };
+
+  // Expect: "opt" | "optUndef"
+  type Keys = OptionalKeys<Props>;
+```
+
+## `Overwrite`
+
+From `U` overwrite properties to `T`
+
+```ts
+export type Overwrite<
+  T extends object,
+  U extends object,
+  I = Diff<T, U> & Intersection<U, T>
+> = Pick<I, keyof I>;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+  type NewProps = { age: string; other: string };
+
+  // Expect: { name: string; age: string; visible: boolean; }
+  type ReplacedProps = Overwrite<Props, NewProps>;
+```
+
+## `PickByValue`
+
+From `T` pick a set of properties by value matching `ValueType`.
+Credit: [Piotr Lewandowski](https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c)
+
+```ts
+export type PickByValue<T, ValueType> = Pick<
+  T,
+  { [Key in keyof T]-?: T[Key] extends ValueType ? Key : never }[keyof T]
+>;
+```
+
+### Examples
+
+```ts
+type Props = { req: number; reqUndef: number | undefined; opt?: string; };
+
+  // Expect: { req: number }
+  type Props = PickByValue<Props, number>;
+  // Expect: { req: number; reqUndef: number | undefined; }
+  type Props = PickByValue<Props, number | undefined>;
+```
+
+## `PickByValueExact`
+
+From `T` pick a set of properties by value matching exact `ValueType`.
+
+```ts
+export type PickByValueExact<T, ValueType> = Pick<
+  T,
+  {
+    [Key in keyof T]-?: [ValueType] extends [T[Key]]
+      ? [T[Key]] extends [ValueType]
+        ? Key
+        : never
+      : never;
+  }[keyof T]
+>;
+```
+
+### Examples
+
+```ts
+type Props = { req: number; reqUndef: number | undefined; opt?: string; };
+
+  // Expect: { req: number }
+  type Props = PickByValueExact<Props, number>;
+  // Expect: { reqUndef: number | undefined; }
+  type Props = PickByValueExact<Props, number | undefined>;
+```
+
+## `PromiseType`
+
+Obtain Promise resolve type
+
+```ts
+export type PromiseType<T extends Promise<any>> = T extends Promise<infer U>
+  ? U
+  : never;
+```
+
+### Examples
+
+```ts
+// Expect: string;
+  type Response = PromiseType<Promise<string>>;
+```
+
+## `ReadonlyKeys`
+
+Get union type of keys that are readonly in object type `T`
+Credit: Matt McCutchen
+https://stackoverflow.com/questions/52443276/how-to-exclude-getter-only-properties-from-type-in-typescript
+
+```ts
+export type ReadonlyKeys<T extends object> = {
+  [P in keyof T]-?: IfEquals<
+    { [Q in P]: T[P] },
+    { -readonly [Q in P]: T[P] },
+    never,
+    P
+  >;
+}[keyof T];
+```
+
+### Examples
+
+```ts
+type Props = { readonly foo: string; bar: number };
+
+  // Expect: "foo"
+  type Keys = ReadonlyKeys<Props>;
+```
+
+## `Required`
+
+From `T` make a set of properties by key `K` become required
+
+Source export: `AugmentedRequired`
+
+```ts
+export type AugmentedRequired<
+  T extends object,
+  K extends keyof T = keyof T
+> = Omit<T, K> & Required<Pick<T, K>>;
+```
+
+### Examples
+
+```ts
+type Props = {
+     name?: string;
+     age?: number;
+     visible?: boolean;
+   };
+
+   // Expect: { name: string; age: number; visible: boolean; }
+   type Props = Required<Props>;
+
+   // Expect: { name?: string; age: number; visible: boolean; }
+   type Props = Required<Props, 'age' | 'visible'>;
+```
+
+## `RequiredKeys`
+
+Get union type of keys that are required in object type `T`
+
+```ts
+export type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+}[keyof T];
+```
+
+### Notes
+
+- `@see` https://stackoverflow.com/questions/52984808/is-there-a-way-to-get-all-required-properties-of-a-typescript-object
+
+### Examples
+
+```ts
+type Props = { req: number; reqUndef: number | undefined; opt?: string; optUndef?: number | undefined; };
+
+  // Expect: "req" | "reqUndef"
+  type Keys = RequiredKeys<Props>;
+```
+
+## `SetComplement`
+
+Set complement of given union types `A` and (it's subset) `A1`
+
+```ts
+export type SetComplement<A, A1 extends A> = SetDifference<A, A1>;
+```
+
+### Examples
+
+```ts
+// Expect: "1"
+  SetComplement<'1' | '2' | '3', '2' | '3'>;
+```
+
+## `SetDifference`
+
+Set difference of given union types `A` and `B`
+
+```ts
+export type SetDifference<A, B> = A extends B ? never : A;
+```
+
+### Examples
+
+```ts
+// Expect: "1"
+  SetDifference<'1' | '2' | '3', '2' | '3' | '4'>;
+
+  // Expect: string | number
+  SetDifference<string | number | (() => void), Function>;
+```
+
+## `SetIntersection`
+
+Set intersection of given union types `A` and `B`
+
+```ts
+export type SetIntersection<A, B> = A extends B ? A : never;
+```
+
+### Examples
+
+```ts
+// Expect: "2" | "3"
+  SetIntersection<'1' | '2' | '3', '2' | '3' | '4'>;
+
+  // Expect: () => void
+  SetIntersection<string | number | (() => void), Function>;
+```
+
+## `Subtract`
+
+From `T` remove properties that exist in `T1` (`T1` has a subset of the properties of `T`)
+
+```ts
+export type Subtract<T extends T1, T1 extends object> = Pick<
+  T,
+  SetComplement<keyof T, keyof T1>
+>;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+  type DefaultProps = { age: number };
+
+  // Expect: { name: string; visible: boolean; }
+  type RestProps = Subtract<Props, DefaultProps>;
+```
+
+## `SymmetricDifference`
+
+Set difference of union and intersection of given union types `A` and `B`
+
+```ts
+export type SymmetricDifference<A, B> = SetDifference<A | B, A & B>;
+```
+
+### Examples
+
+```ts
+// Expect: "1" | "4"
+  SymmetricDifference<'1' | '2' | '3', '2' | '3' | '4'>;
+```
+
+## `Unionize`
+
+Disjoin object to form union of objects, each with single property
+
+```ts
+export type Unionize<T extends object> = {
+  [P in keyof T]: { [Q in P]: T[P] };
+}[keyof T];
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+  // Expect: { name: string; } | { age: number; } | { visible: boolean; }
+  type UnionizedType = Unionize<Props>;
+```
+
+## `UnionKeys`
+
+Get keys of all objects in the union type `U`
+Credit: filipomar
+
+```ts
+export type UnionKeys<U> = keyof UnionToIntersection<Partial<U>>;
+```
+
+### Notes
+
+- `@see` https://github.com/piotrwitek/utility-types/issues/192
+
+### Examples
+
+```ts
+// Expect: 'name' | 'age' | 'visible'
+  UnionKeys<{ name: string; age: string } | { age: number } | { visible: boolean }>
+```
+
+## `UnionToIntersection`
+
+Get intersection type given union type `U`
+Credit: jcalz
+
+```ts
+export type UnionToIntersection<U> = (U extends any
+? (k: U) => void
+: never) extends (k: infer I) => void
+  ? I
+  : never;
+```
+
+### Notes
+
+- `@see` https://stackoverflow.com/a/50375286/7381355
+
+### Examples
+
+```ts
+// Expect: { name: string } & { age: number } & { visible: boolean }
+  UnionToIntersection<{ name: string } | { age: number } | { visible: boolean }>
+```
+
+## `ValuesType`
+
+Get the union type of all the values in an object, array or array-like type `T`
+
+```ts
+export type ValuesType<
+  T extends ReadonlyArray<any> | ArrayLike<any> | Record<any, any>
+> = T extends ReadonlyArray<any>
+  ? T[number]
+  : T extends ArrayLike<any>
+  ? T[number]
+  : T extends object
+  ? T[keyof T]
+  : never;
+```
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+   // Expect: string | number | boolean
+   type PropsValues = ValuesType<Props>;
+
+   type NumberArray = number[];
+   // Expect: number
+   type NumberItems = ValuesType<NumberArray>;
+
+   type ReadonlySymbolArray = readonly symbol[];
+   // Expect: symbol
+   type SymbolItems = ValuesType<ReadonlySymbolArray>;
+
+   type NumberTuple = [1, 2];
+   // Expect: 1 | 2
+   type NumberUnion = ValuesType<NumberTuple>;
+
+   type ReadonlyNumberTuple = readonly [1, 2];
+   // Expect: 1 | 2
+   type AnotherNumberUnion = ValuesType<NumberTuple>;
+
+   type BinaryArray = Uint8Array;
+   // Expect: number
+   type BinaryItems = ValuesType<BinaryArray>;
+```
+
+## `Writable`
+
+```ts
+export type Writable<T> = Mutable<T>;
+```
+
+## `WritableKeys`
+
+```ts
+export type WritableKeys<T extends object> = MutableKeys<T>;
+```

--- a/docs/api/utility-types.md
+++ b/docs/api/utility-types.md
@@ -1,0 +1,261 @@
+# Flow's Utility Types
+
+Generated from `src/utility-types.ts`.
+
+- [`$Call`](#dollar-call)
+- [`$Diff`](#dollar-diff)
+- [`$ElementType`](#dollar-elementtype)
+- [`$Keys`](#dollar-keys)
+- [`$NonMaybeType`](#dollar-nonmaybetype)
+- [`$PropertyType`](#dollar-propertytype)
+- [`$ReadOnly`](#dollar-readonly)
+- [`$Shape`](#dollar-shape)
+- [`$Values`](#dollar-values)
+- [`Class`](#class)
+
+## `$Call`
+
+Get the return type from a given typeof expression
+
+```ts
+export type $Call<Fn extends (...args: any[]) => any> = Fn extends (
+  arg: any
+) => infer RT
+  ? RT
+  : never;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-call
+
+### Examples
+
+```ts
+// Common use-case
+  const add = (amount: number) => ({ type: 'ADD' as 'ADD', payload: amount });
+  type AddAction = $Call<typeof add>; // { type: 'ADD'; payload: number }
+
+  // Examples migrated from Flow docs
+  type ExtractPropType<T extends { prop: any }> = (arg: T) => T['prop'];
+  type Obj = { prop: number };
+  type PropType = $Call<ExtractPropType<Obj>>; // number
+
+  type ExtractReturnType<T extends () => any> = (arg: T) => ReturnType<T>;
+  type Fn = () => number;
+  type FnReturnType = $Call<ExtractReturnType<Fn>>; // number
+```
+
+## `$Diff`
+
+Get the set difference of a given object types `T` and `U` (`T \ U`)
+
+```ts
+export type $Diff<T extends U, U extends object> = Pick<
+  T,
+  SetComplement<keyof T, keyof U>
+>;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-diff
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+  type DefaultProps = { age: number };
+
+  // Expect: { name: string; visible: boolean; }
+  type RequiredProps = Diff<Props, DefaultProps>;
+```
+
+## `$ElementType`
+
+Get the type of elements inside of array, tuple or object of type `T`, that matches the given index type `K`
+
+```ts
+export type $ElementType<
+  T extends { [P in K & any]: any },
+  K extends keyof T | number
+> = T[K];
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-elementtype
+
+### Examples
+
+```ts
+// Expect: string;
+  type Props = { name: string; age: number; visible: boolean };
+  type NameType = $ElementType<Props, 'name'>;
+
+  // Expect: boolean
+  type Tuple = [boolean, number];
+  type A = $ElementType<Tuple, '0'>;
+  // Expect: number
+  type B = $ElementType<Tuple, '1'>;
+
+  // Expect: boolean
+  type Arr = boolean[];
+  type ItemsType = $ElementType<Arr, number>;
+
+  // Expect: number
+  type Obj = { [key: string]: number };
+  type ValuesType = $ElementType<Obj, string>;
+```
+
+## `$Keys`
+
+Get the union type of all the keys in an object type `T`
+
+```ts
+export type $Keys<T extends object> = keyof T;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-keys
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+  // Expect: "name" | "age" | "visible"
+  type PropsKeys = $Keys<Props>;
+```
+
+## `$NonMaybeType`
+
+Excludes null and undefined from T
+
+```ts
+export type $NonMaybeType<T> = NonNullable<T>;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-nonmaybe
+
+### Examples
+
+```ts
+type MaybeName = string | null;
+
+  // Expect: string
+  type Name = $NonMaybeType<MaybeName>;
+```
+
+## `$PropertyType`
+
+Get the type of property of an object at a given key `K`
+
+```ts
+export type $PropertyType<T extends object, K extends keyof T> = T[K];
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-propertytype
+
+### Examples
+
+```ts
+// Expect: string;
+  type Props = { name: string; age: number; visible: boolean };
+  type NameType = $PropertyType<Props, 'name'>;
+
+  // Expect: boolean
+  type Tuple = [boolean, number];
+  type A = $PropertyType<Tuple, '0'>;
+  // Expect: number
+  type B = $PropertyType<Tuple, '1'>;
+```
+
+## `$ReadOnly`
+
+Get the read-only version of a given object type `T` (it works on nested data structure)
+
+```ts
+export type $ReadOnly<T extends object> = DeepReadonly<T>;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-readonly
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+  // Expect: Readonly<{ name: string; age: number; visible: boolean; }>
+  type ReadOnlyProps = $ReadOnly<Props>;
+```
+
+## `$Shape`
+
+Copies the shape of the type supplied, but marks every field optional.
+
+```ts
+export type $Shape<T extends object> = Partial<T>;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-shape
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+  // Expect: Partial<Props>
+  type PartialProps = $Shape<Props>;
+```
+
+## `$Values`
+
+Get the union type of all the values in an object type `T`
+
+```ts
+export type $Values<T extends object> = T[keyof T];
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-values
+
+### Examples
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+  // Expect: string | number | boolean
+  type PropsValues = $Values<Props>;
+```
+
+## `Class`
+
+Represents constructor of type T
+
+```ts
+export type Class<T> = new (...args: any[]) => T;
+```
+
+### Notes
+
+- `@see` https://flow.org/en/docs/types/utilities/#toc-class
+
+### Examples
+
+```ts
+class Store {}
+  function makeStore(storeClass: Class<Store>): Store {
+    return new storeClass();
+  }
+```

--- a/docs/api/utility-types.md
+++ b/docs/api/utility-types.md
@@ -68,7 +68,7 @@ type Props = { name: string; age: number; visible: boolean };
   type DefaultProps = { age: number };
 
   // Expect: { name: string; visible: boolean; }
-  type RequiredProps = Diff<Props, DefaultProps>;
+  type RequiredProps = $Diff<Props, DefaultProps>;
 ```
 
 ## `$ElementType`

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>utility-types API</title>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'utility-types',
+      loadSidebar: true,
+      subMaxLevel: 2,
+      search: {
+        placeholder: 'Search API',
+        noData: 'No results',
+      },
+    };
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "jest --config jest.config.json && dts-jest-remap ./src/*.spec.ts --rename {{basename}}.snap.{{extname}} --check",
     "test:update": "jest --config jest.config.json --no-cache -u && dts-jest-remap ./src/*.spec.ts --rename {{basename}}.snap.{{extname}}",
     "test:watch": "jest --config jest.config.json --watch",
+    "docs:api": "node scripts/generate-api-docs.js",
     "prebuild": "rm -rf dist/",
     "build": "tsc -p ./tsconfig.build.json --outDir dist/",
     "prepublishOnly": "npm run reinstall && npm run ci-check && npm run build"

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -1,0 +1,395 @@
+/* eslint-disable no-console */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var ts = require('typescript');
+
+var rootDir = path.resolve(__dirname, '..');
+var docsDir = path.join(rootDir, 'docs');
+var apiDir = path.join(docsDir, 'api');
+var srcDir = path.join(rootDir, 'src');
+var moduleTitles = {
+  'aliases-and-guards.ts': 'Aliases & Type Guards',
+  'mapped-types.ts': 'Mapped Types',
+  'utility-types.ts': "Flow's Utility Types",
+  'functional-helpers.ts': 'Deprecated API',
+};
+var moduleOrder = [
+  'mapped-types.ts',
+  'utility-types.ts',
+  'aliases-and-guards.ts',
+  'functional-helpers.ts',
+];
+
+function mkdirp(dir) {
+  if (fs.existsSync(dir)) {
+    return;
+  }
+  mkdirp(path.dirname(dir));
+  fs.mkdirSync(dir);
+}
+
+function writeFile(filePath, content) {
+  mkdirp(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function cleanDir(dir) {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  fs.readdirSync(dir).forEach(function(fileName) {
+    var filePath = path.join(dir, fileName);
+    if (fs.statSync(filePath).isDirectory()) {
+      cleanDir(filePath);
+      fs.rmdirSync(filePath);
+    } else {
+      fs.unlinkSync(filePath);
+    }
+  });
+}
+
+function readTsConfig() {
+  var configPath = path.join(rootDir, 'tsconfig.json');
+  var configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (configFile.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'));
+  }
+  return ts.parseJsonConfigFileContent(configFile.config, ts.sys, rootDir);
+}
+
+function hasPrivateTag(node) {
+  return ts.getJSDocTags(node).some(function(tag) {
+    return tag.tagName && tag.tagName.text === 'private';
+  });
+}
+
+function findPublicDeclaration(declarations) {
+  return declarations.filter(function(declaration) {
+    var sourceFile = declaration.getSourceFile();
+    var fileName = path.basename(sourceFile.fileName);
+
+    return (
+      sourceFile.fileName.indexOf(srcDir) === 0 &&
+      fileName !== 'index.ts' &&
+      fileName.indexOf('.spec') === -1 &&
+      fileName.indexOf('.snap') === -1 &&
+      !hasPrivateTag(declaration)
+    );
+  })[0];
+}
+
+function displayPartsToString(parts) {
+  if (!parts) {
+    return '';
+  }
+  if (typeof parts === 'string') {
+    return parts;
+  }
+  if (Array.isArray(parts)) {
+    return parts
+      .map(function(part) {
+        return typeof part === 'string' ? part : part.text || '';
+      })
+      .join('');
+  }
+  return String(parts);
+}
+
+function getTagText(tag) {
+  return displayPartsToString(tag.text).trim();
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/^\$/, 'dollar-')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function getModuleSlug(fileName) {
+  return fileName.replace(/\.ts$/, '');
+}
+
+function stripJsDoc(text) {
+  return text.replace(/^\/\*\*[\s\S]*?\*\/\s*/, '');
+}
+
+function trimImplementation(text) {
+  var stripped = stripJsDoc(text).trim();
+  var arrowIndex = stripped.indexOf('=> {');
+  if (arrowIndex !== -1) {
+    return stripped.slice(0, arrowIndex + 2).trim() + ' ...';
+  }
+  return stripped;
+}
+
+function getDeclarationSnippet(declaration, publicName, checker) {
+  if (ts.isVariableDeclaration(declaration)) {
+    var type = checker.typeToString(checker.getTypeAtLocation(declaration.name));
+    return 'export const ' + publicName + ': ' + type + ';';
+  }
+
+  return trimImplementation(declaration.getText(declaration.getSourceFile()));
+}
+
+function getSymbolDocumentation(symbol, checker) {
+  var docs = displayPartsToString(symbol.getDocumentationComment(checker)).trim();
+  var tags = symbol.getJsDocTags(checker);
+  var descriptionTags = tags
+    .filter(function(tag) {
+      return tag.name === 'desc';
+    })
+    .map(getTagText)
+    .filter(Boolean);
+
+  if (descriptionTags.length > 0) {
+    return descriptionTags.join('\n\n');
+  }
+
+  return docs;
+}
+
+function getExamples(symbol, checker) {
+  return symbol
+    .getJsDocTags(checker)
+    .filter(function(tag) {
+      return tag.name === 'example';
+    })
+    .map(getTagText)
+    .filter(Boolean);
+}
+
+function getNotes(symbol, checker) {
+  var skipTags = { desc: true, example: true };
+
+  return symbol
+    .getJsDocTags(checker)
+    .filter(function(tag) {
+      return !skipTags[tag.name];
+    })
+    .map(function(tag) {
+      return {
+        name: tag.name,
+        text: getTagText(tag),
+      };
+    })
+    .filter(function(tag) {
+      return tag.text;
+    });
+}
+
+function getExports(program, checker) {
+  var index = program.getSourceFile(path.join(srcDir, 'index.ts'));
+  var moduleSymbol = checker.getSymbolAtLocation(index);
+
+  return checker
+    .getExportsOfModule(moduleSymbol)
+    .map(function(exportSymbol) {
+      var targetSymbol =
+        exportSymbol.flags & ts.SymbolFlags.Alias
+          ? checker.getAliasedSymbol(exportSymbol)
+          : exportSymbol;
+      var declarations = targetSymbol.getDeclarations() || [];
+      var declaration = findPublicDeclaration(declarations);
+
+      if (!declaration) {
+        return null;
+      }
+
+      var sourceFile = declaration.getSourceFile();
+      var sourceName = path.basename(sourceFile.fileName);
+      var publicName = exportSymbol.getName();
+      var sourceNameText = targetSymbol.getName();
+
+      return {
+        name: publicName,
+        sourceName: sourceNameText,
+        moduleTitle: moduleTitles[sourceName] || sourceName,
+        moduleSlug: getModuleSlug(sourceName),
+        fileName: sourceName,
+        slug: slugify(publicName),
+        documentation: getSymbolDocumentation(targetSymbol, checker),
+        examples: getExamples(targetSymbol, checker),
+        notes: getNotes(targetSymbol, checker),
+        snippet: getDeclarationSnippet(declaration, publicName, checker),
+        isAlias: publicName !== sourceNameText,
+      };
+    })
+    .filter(Boolean)
+    .sort(function(a, b) {
+      if (a.fileName !== b.fileName) {
+        return moduleOrder.indexOf(a.fileName) - moduleOrder.indexOf(b.fileName);
+      }
+      return a.name.localeCompare(b.name);
+    });
+}
+
+function groupByModule(items) {
+  return items.reduce(function(groups, item) {
+    if (!groups[item.moduleTitle]) {
+      groups[item.moduleTitle] = [];
+    }
+    groups[item.moduleTitle].push(item);
+    return groups;
+  }, {});
+}
+
+function getOrderedModuleTitles(groups) {
+  return moduleOrder
+    .map(function(fileName) {
+      return moduleTitles[fileName];
+    })
+    .filter(function(moduleTitle) {
+      return groups[moduleTitle] && groups[moduleTitle].length > 0;
+    });
+}
+
+function renderModulePage(moduleTitle, items) {
+  var sourceFile = items[0].fileName;
+  var lines = [
+    '# ' + moduleTitle,
+    '',
+    'Generated from `src/' + sourceFile + '`.',
+    '',
+  ];
+
+  items.forEach(function(item) {
+    lines.push('- [`' + item.name + '`](#' + item.slug + ')');
+  });
+  lines.push('');
+
+  items.forEach(function(item) {
+    lines.push('## `' + item.name + '`', '');
+
+    if (item.documentation) {
+      lines.push(item.documentation, '');
+    }
+
+    if (item.isAlias) {
+      lines.push('Source export: `' + item.sourceName + '`', '');
+    }
+
+    lines.push('```ts', item.snippet, '```', '');
+
+    if (item.notes.length > 0) {
+      lines.push('### Notes', '');
+      item.notes.forEach(function(note) {
+        lines.push('- `@' + note.name + '` ' + note.text);
+      });
+      lines.push('');
+    }
+
+    if (item.examples.length > 0) {
+      lines.push('### Examples', '');
+      item.examples.forEach(function(example) {
+        lines.push('```ts', example, '```', '');
+      });
+    }
+  });
+
+  return lines.join('\n');
+}
+
+function renderReadme(groups) {
+  var lines = [
+    '# utility-types API',
+    '',
+    'This documentation is generated from the exported TypeScript declarations and JSDoc comments in `src/`.',
+    '',
+    'Run `npm run docs:api` after source changes to refresh the pages and sidebar.',
+    '',
+  ];
+
+  getOrderedModuleTitles(groups).forEach(function(moduleTitle) {
+    var items = groups[moduleTitle];
+    var exportText = items.length === 1 ? ' export' : ' exports';
+    lines.push(
+      '- [' +
+        moduleTitle +
+        '](api/' +
+        items[0].moduleSlug +
+        '.md) - ' +
+        items.length +
+        exportText +
+        ' from `src/' +
+        items[0].fileName +
+        '`'
+    );
+  });
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function renderSidebar(groups) {
+  var lines = ['- [Overview](README.md)'];
+
+  getOrderedModuleTitles(groups).forEach(function(moduleTitle) {
+    var items = groups[moduleTitle];
+    lines.push('- [' + moduleTitle + '](api/' + items[0].moduleSlug + '.md)');
+  });
+
+  return lines.join('\n') + '\n';
+}
+
+function renderIndexHtml() {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    '  <title>utility-types API</title>',
+    '  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">',
+    '</head>',
+    '<body>',
+    '  <div id="app"></div>',
+    '  <script>',
+    '    window.$docsify = {',
+    "      name: 'utility-types',",
+    '      loadSidebar: true,',
+    '      subMaxLevel: 2,',
+    '      search: {',
+    "        placeholder: 'Search API',",
+    "        noData: 'No results',",
+    '      },',
+    '    };',
+    '  </script>',
+    '  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>',
+    '  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>',
+    '</body>',
+    '</html>',
+    '',
+  ].join('\n');
+}
+
+function main() {
+  var parsedConfig = readTsConfig();
+  var program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options);
+  var checker = program.getTypeChecker();
+  var items = getExports(program, checker);
+  var groups = groupByModule(items);
+
+  cleanDir(apiDir);
+  mkdirp(apiDir);
+
+  getOrderedModuleTitles(groups).forEach(function(moduleTitle) {
+    var moduleItems = groups[moduleTitle];
+    writeFile(
+      path.join(apiDir, moduleItems[0].moduleSlug + '.md'),
+      renderModulePage(moduleTitle, moduleItems)
+    );
+  });
+
+  writeFile(path.join(docsDir, 'README.md'), renderReadme(groups));
+  writeFile(path.join(docsDir, '_sidebar.md'), renderSidebar(groups));
+  writeFile(path.join(docsDir, 'index.html'), renderIndexHtml());
+  writeFile(path.join(docsDir, '.nojekyll'), '');
+
+  console.log('Generated ' + items.length + ' API entries in docs/.');
+}
+
+main();

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -117,22 +117,23 @@ function stripJsDoc(text) {
   return text.replace(/^\/\*\*[\s\S]*?\*\/\s*/, '');
 }
 
-function trimImplementation(text) {
-  var stripped = stripJsDoc(text).trim();
-  var arrowIndex = stripped.indexOf('=> {');
-  if (arrowIndex !== -1) {
-    return stripped.slice(0, arrowIndex + 2).trim() + ' ...';
-  }
-  return stripped;
-}
-
 function getDeclarationSnippet(declaration, publicName, checker) {
   if (ts.isVariableDeclaration(declaration)) {
     var type = checker.typeToString(checker.getTypeAtLocation(declaration.name));
     return 'export const ' + publicName + ': ' + type + ';';
   }
 
-  return trimImplementation(declaration.getText(declaration.getSourceFile()));
+  var sourceFile = declaration.getSourceFile();
+  var text = declaration.getText(sourceFile);
+  var stripped = stripJsDoc(text).trim();
+
+  if (ts.isFunctionDeclaration(declaration) && declaration.body) {
+    var bodyStart = declaration.body.getStart(sourceFile);
+    var nodeStart = declaration.getStart(sourceFile);
+    return stripped.slice(0, bodyStart - nodeStart).trim() + ';';
+  }
+
+  return stripped;
 }
 
 function getSymbolDocumentation(symbol, checker) {
@@ -182,8 +183,15 @@ function getNotes(symbol, checker) {
 }
 
 function getExports(program, checker) {
-  var index = program.getSourceFile(path.join(srcDir, 'index.ts'));
+  var indexFile = path.join(srcDir, 'index.ts');
+  var index = program.getSourceFile(indexFile);
+  if (!index) {
+    throw new Error('Could not find entry point: ' + indexFile);
+  }
   var moduleSymbol = checker.getSymbolAtLocation(index);
+  if (!moduleSymbol) {
+    throw new Error('Could not read module symbol for entry point: ' + indexFile);
+  }
 
   return checker
     .getExportsOfModule(moduleSymbol)

--- a/src/aliases-and-guards.ts
+++ b/src/aliases-and-guards.ts
@@ -29,7 +29,7 @@ export type Falsy = false | '' | 0 | null | undefined;
 
 /**
  * Nullish
- * @desc Type representing [nullish values][https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing] in TypeScript: `null | undefined`
+ * @desc Type representing [nullish values](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing) in TypeScript: `null | undefined`
  * @example
  *   type Various = 'a' | 'b' | undefined;
  *

--- a/src/mapped-types.ts
+++ b/src/mapped-types.ts
@@ -52,7 +52,7 @@ export type SymmetricDifference<A, B> = SetDifference<A | B, A & B>;
  * @desc Exclude undefined from set `A`
  * @example
  *   // Expect: "string | null"
- *   SymmetricDifference<string | null | undefined>;
+ *   NonUndefined<string | null | undefined>;
  */
 export type NonUndefined<A> = A extends undefined ? never : A;
 

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -45,7 +45,7 @@ export type $ReadOnly<T extends object> = DeepReadonly<T>;
  *   type DefaultProps = { age: number };
  *
  *   // Expect: { name: string; visible: boolean; }
- *   type RequiredProps = Diff<Props, DefaultProps>;
+ *   type RequiredProps = $Diff<Props, DefaultProps>;
  */
 export type $Diff<T extends U, U extends object> = Pick<
   T,


### PR DESCRIPTION
## Summary

Fixes #30.

This adds a working proof-of-concept for generated API docs that follows the direction discussed in the issue:

- parses the public exports from `src/index.ts` with the existing TypeScript compiler dependency
- reads JSDoc descriptions, tags, examples, aliases, and declaration snippets from the source files
- generates markdown subpages per source module under `docs/api/`
- serves the markdown with a small Docsify shell and built-in search
- adds `npm run docs:api` so docs can be refreshed after API/JSDoc changes

I avoided Typedoc here because the issue discussion called out its UX/search/export-name problems. This POC keeps the generated output markdown-based and handles public re-export names such as `Required` while still noting their source declaration when aliased.

## Validation

- `npm run docs:api`
- `npm run ci-check`
- `git diff --check`
- served `docs/` locally and verified the Docsify sidebar/search flow with `DeepReadonly`
- push hook also ran `prettier:fix`, `lint`, `tsc`, and `test:update`

## Transparency

This PR was prepared with AI assistance. I reviewed the generated code and docs locally, ran the validation above, and kept the change limited to the documentation POC for the funded IssueHunt issue.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#30: Add a web page with API documentation hosted on github pages](https://oss.issuehunt.io/repos/76400842/issues/30)
---
</details>
<!-- /Issuehunt content-->