### PR TITLE
docs: add missing built-in utility examples in API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,10 +694,10 @@ Make all properties of object type optional
 **Usage:**
 
 ```ts
-type Props = { name: string; age: number; visible: boolean };
+type Props = { name: string; age: number; visible: boolean; };
 
 // Expect: { name?: string; age?: number; visible?: boolean; }
-type PartialProps = Partial<Props>;
+type Props = Partial<Props>;
 ```
 
 [⇧ back to top](#table-of-contents)
@@ -728,10 +728,10 @@ Make all properties of object type readonly
 **Usage:**
 
 ```ts
-type Props = { name: string; age: number; visible: boolean };
+type Props = { name: string; age: number; visible: boolean; };
 
 // Expect: { readonly name: string; readonly age: number; readonly visible: boolean; }
-type ReadonlyProps = Readonly<Props>;
+type Props = Readonly<Props>;
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -691,6 +691,15 @@ type BinaryItems = ValuesType<BinaryArray>;
 
 Make all properties of object type optional
 
+**Usage:**
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+// Expect: { name?: string; age?: number; visible?: boolean; }
+type PartialProps = Partial<Props>;
+```
+
 [⇧ back to top](#table-of-contents)
 
 ### `Required<T, K>`
@@ -715,6 +724,15 @@ type Props = Required<Props, 'age' | 'visible'>;
 ### `Readonly<T>`
 
 Make all properties of object type readonly
+
+**Usage:**
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+// Expect: { readonly name: string; readonly age: number; readonly visible: boolean; }
+type ReadonlyProps = Readonly<Props>;
+```
 
 [⇧ back to top](#table-of-contents)
 
@@ -743,11 +761,31 @@ Mutable<Props>;
 
 Obtain the return type of a function
 
+**Usage:**
+
+```ts
+type Fn = (name: string) => { greeting: string };
+
+// Expect: { greeting: string; }
+type FnReturn = ReturnType<Fn>;
+```
+
 [⇧ back to top](#table-of-contents)
 
 ### `InstanceType<T>`
 
 Obtain the instance type of a class
+
+**Usage:**
+
+```ts
+class Store {
+  state = { ready: true };
+}
+
+// Expect: Store
+type StoreInstance = InstanceType<typeof Store>;
+```
 
 [⇧ back to top](#table-of-contents)
 


### PR DESCRIPTION
## Summary
- add missing examples for built-in utility types: `Partial`, `Readonly`, `ReturnType`, and `InstanceType`
- keep example style aligned with existing README API sections

## Context
This addresses the IssueHunt-funded docs improvement request in #51.

## Testing
- docs-only change


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#51: Improve organization and add missing examples in API documentation](https://oss.issuehunt.io/repos/76400842/issues/51)
---
</details>
<!-- /Issuehunt content-->