### PR TITLE
docs(readme): add missing usage examples for core utility aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ class Store {
   state = { ready: true };
 }
 
-// Expect: Store
+// Expect: { state: { ready: boolean } }
 type StoreInstance = InstanceType<typeof Store>;
 ```
 

--- a/README.md
+++ b/README.md
@@ -691,6 +691,15 @@ type BinaryItems = ValuesType<BinaryArray>;
 
 Make all properties of object type optional
 
+**Usage:**
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+// Expect: { name?: string; age?: number; visible?: boolean; }
+type PartialProps = Partial<Props>;
+```
+
 [⇧ back to top](#table-of-contents)
 
 ### `Required<T, K>`
@@ -715,6 +724,15 @@ type Props = Required<Props, 'age' | 'visible'>;
 ### `Readonly<T>`
 
 Make all properties of object type readonly
+
+**Usage:**
+
+```ts
+type Props = { name: string; age: number; visible: boolean };
+
+// Expect: { readonly name: string; readonly age: number; readonly visible: boolean; }
+type ReadonlyProps = Readonly<Props>;
+```
 
 [⇧ back to top](#table-of-contents)
 
@@ -743,11 +761,31 @@ Mutable<Props>;
 
 Obtain the return type of a function
 
+**Usage:**
+
+```ts
+type Fn = (name: string) => { greeting: string };
+
+// Expect: { greeting: string; }
+type FnReturn = ReturnType<Fn>;
+```
+
 [⇧ back to top](#table-of-contents)
 
 ### `InstanceType<T>`
 
 Obtain the instance type of a class
+
+**Usage:**
+
+```ts
+class Store {
+  state = { ready: true };
+}
+
+// Expect: Store
+type StoreInstance = InstanceType<typeof Store>;
+```
 
 [⇧ back to top](#table-of-contents)
 


### PR DESCRIPTION
﻿## Summary
- add explicit usage snippets for several core built-in utility aliases in the README API section
- document concrete expected resulting types for `Partial`, `Readonly`, `ReturnType`, and `InstanceType`
- improve readability and discoverability of examples while preserving existing structure

## Why
Issue #51 asks for better API documentation organization and missing examples. These additions fill common gaps in quick-reference usage.

## Validation
- documentation-only update
- snippets follow existing README style and type alias conventions
