### PR TITLE
Add $ObjMap type utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ We are open for contributions. If you're planning to contribute please make sure
 * [`$PropertyType<T, K>`](#propertytypet-k)
 * [`$ElementType<T, K>`](#elementtypet-k)
 * [`$Call<T>`](#callt)
+* [`$ObjMap<T, Fn>`](#objmapt-fn)
 * [`$Shape<T>`](#shapet)
 * [`$NonMaybeType<T>`](#nonmaybetypet)
 * [`Class<T>`](#classt)
@@ -1096,6 +1097,33 @@ type PropType = $Call<ExtractPropType<Obj>>; // number
 type ExtractReturnType<T extends () => any> = (arg: T) => ReturnType<T>;
 type Fn = () => number;
 type FnReturnType = $Call<ExtractReturnType<Fn>>; // number
+```
+
+[⇧ back to top](#flows-utility-types)
+
+### `$ObjMap<T, Fn>`
+
+Maps each property value of a given object type `T` through a type-level mapper `Fn`.<br>
+https://flow.org/en/docs/types/utilities/#toc-objmap
+
+TypeScript does not support passing generic type aliases directly, so mapper types are defined as interfaces extending `$ObjMapFn`. The mapper receives each property value as `this['input']` and exposes the mapped result as `type`.
+
+**Usage:**
+
+```ts
+import { $ObjMap, $ObjMapFn } from 'utility-types';
+
+interface MapToReturnType extends $ObjMapFn {
+  type: this['input'] extends (...args: any[]) => infer R ? R : never;
+}
+
+type Props = {
+  a: () => boolean;
+  b: () => 'foo';
+};
+
+// Expect: { a: boolean; b: 'foo'; }
+type Result = $ObjMap<Props, MapToReturnType>;
 ```
 
 [⇧ back to top](#flows-utility-types)

--- a/src/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__snapshots__/utility-types.spec.ts.snap
@@ -22,6 +22,14 @@ exports[`$Keys testType<$Keys<Props>>() (type) should match snapshot 1`] = `"\\"
 
 exports[`$NonMaybeType testType<$NonMaybeType<string | null | undefined>>() (type) should match snapshot 1`] = `"string"`;
 
+exports[`$ObjMap testType<Result>() (type) should match snapshot 1`] = `"$ObjMap<ObjMapInput, MapToReturnType>"`;
+
+exports[`$ObjMap testType<Result['a']>() (type) should match snapshot 1`] = `"boolean"`;
+
+exports[`$ObjMap testType<Result['b']>() (type) should match snapshot 1`] = `"\\"foo\\""`;
+
+exports[`$ObjMap testType<Result['c']>() (type) should match snapshot 1`] = `"1 | undefined"`;
+
 exports[`$PropertyType testType<$PropertyType<[boolean, number], '0'>>() (type) should match snapshot 1`] = `"boolean"`;
 
 exports[`$PropertyType testType<$PropertyType<[boolean, number], '1'>>() (type) should match snapshot 1`] = `"number"`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export {
   $ElementType,
   $Keys,
   $NonMaybeType,
+  $ObjMap,
+  $ObjMapFn,
   $PropertyType,
   $ReadOnly,
   $Shape,

--- a/src/utility-types.spec.snap.ts
+++ b/src/utility-types.spec.snap.ts
@@ -7,6 +7,8 @@ import {
   $Diff,
   $PropertyType,
   $ElementType,
+  $ObjMap,
+  $ObjMapFn,
   $Shape,
   $NonMaybeType,
   Class,
@@ -19,6 +21,15 @@ import { _DeepReadonlyObject } from './mapped-types';
 
 type Props = { name: string; age: number; visible: boolean };
 type DefaultProps = { age: number };
+type ObjMapInput = {
+  a: () => boolean;
+  b: () => 'foo';
+  c?: () => 1;
+};
+
+interface MapToReturnType extends $ObjMapFn {
+  type: this['input'] extends (...args: any[]) => infer R ? R : never;
+}
 
 class Foo {}
 
@@ -95,6 +106,20 @@ class Foo {}
   type FnReturnType = $Call<ExtractReturnType<Fn>>;
   // @dts-jest:pass:snap -> number
   testType<FnReturnType>();
+}
+
+// @dts-jest:group $ObjMap
+{
+  type Result = $ObjMap<ObjMapInput, MapToReturnType>;
+
+  // @dts-jest:pass:snap -> $ObjMap<ObjMapInput, MapToReturnType>
+  testType<Result>();
+  // @dts-jest:pass:snap -> boolean
+  testType<Result['a']>();
+  // @dts-jest:pass:snap -> "foo"
+  testType<Result['b']>();
+  // @dts-jest:pass:snap -> 1 | undefined
+  testType<Result['c']>();
 }
 
 // @dts-jest:group $Shape

--- a/src/utility-types.spec.ts
+++ b/src/utility-types.spec.ts
@@ -7,6 +7,8 @@ import {
   $Diff,
   $PropertyType,
   $ElementType,
+  $ObjMap,
+  $ObjMapFn,
   $Shape,
   $NonMaybeType,
   Class,
@@ -19,6 +21,15 @@ import { _DeepReadonlyObject } from './mapped-types';
 
 type Props = { name: string; age: number; visible: boolean };
 type DefaultProps = { age: number };
+type ObjMapInput = {
+  a: () => boolean;
+  b: () => 'foo';
+  c?: () => 1;
+};
+
+interface MapToReturnType extends $ObjMapFn {
+  type: this['input'] extends (...args: any[]) => infer R ? R : never;
+}
 
 class Foo {}
 
@@ -95,6 +106,20 @@ class Foo {}
   type FnReturnType = $Call<ExtractReturnType<Fn>>;
   // @dts-jest:pass:snap
   testType<FnReturnType>();
+}
+
+// @dts-jest:group $ObjMap
+{
+  type Result = $ObjMap<ObjMapInput, MapToReturnType>;
+
+  // @dts-jest:pass:snap
+  testType<Result>();
+  // @dts-jest:pass:snap
+  testType<Result['a']>();
+  // @dts-jest:pass:snap
+  testType<Result['b']>();
+  // @dts-jest:pass:snap
+  testType<Result['c']>();
 }
 
 // @dts-jest:group $Shape

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,4 +1,4 @@
-import { SetComplement, DeepReadonly } from './mapped-types';
+import { SetComplement, DeepReadonly, NonUndefined } from './mapped-types';
 
 /**
  * $Keys
@@ -120,6 +120,39 @@ export type $Call<Fn extends (...args: any[]) => any> = Fn extends (
 ) => infer RT
   ? RT
   : never;
+
+/**
+ * $ObjMapFn
+ * @desc Base interface for defining type-level mappers consumed by `$ObjMap`.
+ * @example
+ *   interface MapToReturnType extends $ObjMapFn {
+ *     type: this['input'] extends (...args: any[]) => infer R ? R : never;
+ *   }
+ */
+export interface $ObjMapFn {
+  input: unknown;
+  type: unknown;
+}
+
+type $ObjMapApply<Fn extends $ObjMapFn, Input> = (Fn & {
+  input: Input;
+})['type'];
+
+/**
+ * $ObjMap
+ * @desc Map each property value of a given object type `T` through a type-level mapper `Fn`.
+ * @see https://flow.org/en/docs/types/utilities/#toc-objmap
+ * @example
+ *   interface MapToReturnType extends $ObjMapFn {
+ *     type: this['input'] extends (...args: any[]) => infer R ? R : never;
+ *   }
+ *
+ *   type Props = { a: () => boolean; b: () => 'foo' };
+ *   type Result = $ObjMap<Props, MapToReturnType>; // { a: boolean; b: 'foo' }
+ */
+export type $ObjMap<T extends object, Fn extends $ObjMapFn> = {
+  [K in keyof T]: $ObjMapApply<Fn, NonUndefined<T[K]>>;
+};
 
 /**
  * $Shape


### PR DESCRIPTION
## Summary

- add `$ObjMapFn` and `$ObjMap<T, Fn>` so object property values can be mapped through a type-level mapper
- export the new utility and document the mapper pattern in the README
- add dts-jest coverage and snapshots for the mapped object and optional property behavior

## Verification

- `node node_modules/prettier/bin-prettier.js --list-different src/utility-types.ts src/utility-types.spec.ts src/utility-types.spec.snap.ts src/index.ts`
- `node node_modules/typescript/bin/tsc -p . --noEmit`
- `node node_modules/tslint/bin/tslint --project ./tsconfig.json`
- `node node_modules/jest/bin/jest.js --config jest.config.json --no-cache --testMatch "**/src/utility-types.spec.ts"`
- `node node_modules/dts-jest/bin/dts-jest-remap.js ./src/utility-types.spec.ts --rename "{{basename}}.snap.{{extname}}" --check`
- `git diff --check`

## Notes

Fixes #18.

Prepared with Codex assistance from the Davifek fork.
